### PR TITLE
feature: extension view event listeners

### DIFF
--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -15,6 +15,15 @@ export interface ViewEvent {
   readonly value?: unknown
 }
 
+export interface DomEventListener {
+  readonly capture?: boolean
+  readonly name: string | number
+  readonly params: readonly string[]
+  readonly passive?: boolean
+  readonly preventDefault?: boolean
+  readonly stopPropagation?: boolean
+}
+
 export interface VirtualDomViewInstance {
   readonly dispose?: () => unknown
   readonly handleEvent?: (event: ViewEvent) => unknown
@@ -25,6 +34,7 @@ export interface VirtualDomViewInstance {
 export interface View {
   readonly create: (context?: ViewContext) => unknown
   readonly displayName?: string
+  readonly eventListeners?: readonly DomEventListener[]
   readonly icon?: string
   readonly id: string
   readonly kind?: ViewKind
@@ -34,6 +44,7 @@ export interface View {
 
 export interface RegisteredView {
   readonly displayName?: string
+  readonly eventListeners?: readonly DomEventListener[]
   readonly icon?: string
   readonly id: string
   readonly kind?: ViewKind

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -47,9 +47,9 @@ const assertEventListeners = (view: View): void => {
   if (!Array.isArray(view.eventListeners)) {
     throw new ExtensionApiError(`view ${view.id} eventListeners must be an array`)
   }
-  view.eventListeners.forEach((listener, index) => {
+  for (const [index, listener] of view.eventListeners.entries()) {
     assertEventListener(view.id, listener, index)
-  })
+  }
 }
 
 const assertView = (view: View): void => {

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -1,12 +1,56 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { diffTree, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import type { Disposable } from '../Disposable/Disposable.ts'
-import type { RegisteredView, View, ViewContext, ViewEvent, ViewRegistrySnapshot, ViewRenderResult, VirtualDomViewInstance } from '../View/View.ts'
+import type {
+  DomEventListener,
+  RegisteredView,
+  View,
+  ViewContext,
+  ViewEvent,
+  ViewRegistrySnapshot,
+  ViewRenderResult,
+  VirtualDomViewInstance,
+} from '../View/View.ts'
 import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
 
 const views: Record<string, View> = Object.create(null)
 const instances: Record<number, VirtualDomViewInstance> = Object.create(null)
 const renderedDoms: Record<number, readonly VirtualDomNode[]> = Object.create(null)
+
+const assertBoolean = (value: unknown, message: string): void => {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new ExtensionApiError(message)
+  }
+}
+
+const assertEventListener: (viewId: string, listener: unknown, index: number) => asserts listener is DomEventListener = (viewId, listener, index) => {
+  if (!listener || typeof listener !== 'object') {
+    throw new ExtensionApiError(`view ${viewId} event listener ${index} must be an object`)
+  }
+  const eventListener = listener as DomEventListener
+  if (typeof eventListener.name !== 'string' && typeof eventListener.name !== 'number') {
+    throw new ExtensionApiError(`view ${viewId} event listener ${index} is missing name`)
+  }
+  if (!Array.isArray(eventListener.params) || eventListener.params.some((param) => typeof param !== 'string')) {
+    throw new ExtensionApiError(`view ${viewId} event listener ${index} is missing params`)
+  }
+  assertBoolean(eventListener.capture, `view ${viewId} event listener ${index} has invalid capture`)
+  assertBoolean(eventListener.passive, `view ${viewId} event listener ${index} has invalid passive`)
+  assertBoolean(eventListener.preventDefault, `view ${viewId} event listener ${index} has invalid preventDefault`)
+  assertBoolean(eventListener.stopPropagation, `view ${viewId} event listener ${index} has invalid stopPropagation`)
+}
+
+const assertEventListeners = (view: View): void => {
+  if (view.eventListeners === undefined) {
+    return
+  }
+  if (!Array.isArray(view.eventListeners)) {
+    throw new ExtensionApiError(`view ${view.id} eventListeners must be an array`)
+  }
+  view.eventListeners.forEach((listener, index) => {
+    assertEventListener(view.id, listener, index)
+  })
+}
 
 const assertView = (view: View): void => {
   if (!view) {
@@ -21,12 +65,14 @@ const assertView = (view: View): void => {
   if (view.id in views) {
     throw new ExtensionApiError(`view ${view.id} is already registered`)
   }
+  assertEventListeners(view)
 }
 
 const toRegisteredView = (view: View): RegisteredView => {
   const displayName = view.displayName || view.name || view.title
   const registeredView: RegisteredView = {
     displayName,
+    ...(view.eventListeners && { eventListeners: view.eventListeners }),
     icon: view.icon,
     id: view.id,
     name: view.name,

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -142,6 +142,63 @@ test('registerView includes virtual dom kind in registry snapshot', () => {
   })
 })
 
+test('registerView includes event listeners in registry snapshot', () => {
+  const eventListeners = [
+    {
+      name: 'handleDragStart',
+      params: ['handleViewEvent', 'dragstart', 'event.target.name'],
+    },
+    {
+      name: 'handleDrop',
+      params: ['handleViewEvent', 'drop', 'event.target.name'],
+      preventDefault: true,
+    },
+  ]
+  registerView({
+    create() {
+      return {
+        render() {
+          return []
+        },
+      }
+    },
+    eventListeners,
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  deepStrictEqual(getViewRegistrySnapshot(), {
+    views: [
+      {
+        displayName: undefined,
+        eventListeners,
+        icon: undefined,
+        id: 'sample.views.testing',
+        kind: 'virtualDom',
+        name: undefined,
+        title: undefined,
+      },
+    ],
+  })
+})
+
+test('registerView rejects invalid event listeners', () => {
+  throws(() => {
+    registerView({
+      create() {},
+      eventListeners: [
+        {
+          name: 'handleClick',
+          params: ['handleClick'],
+          preventDefault: 'yes',
+        },
+      ],
+      id: 'sample.views.testing',
+      kind: 'virtualDom',
+    } as any)
+  }, /view sample\.views\.testing event listener 0 has invalid preventDefault/)
+})
+
 test('createViewInstance renders initial virtual dom', async () => {
   registerView({
     create(context) {


### PR DESCRIPTION
## Summary
- Extend the extension API view contract with optional static virtual DOM event listener metadata.
- Validate listener metadata during view registration.
- Include event listeners in the view registry snapshot for isolated extension workers.

## Validation
- `npm test -- --runTestsByPath test/parts/ViewRegistry/ViewRegistry.test.ts`
- `npm run type-check`