### PR TITLE
feature: extension view focus management

### DIFF
--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -41,6 +41,7 @@ export interface VirtualDomViewInstance {
   readonly getMenuEntries?: (menuId: string) => readonly MenuEntry[] | Promise<readonly MenuEntry[]>
   readonly handleEvent?: (event: ViewEvent) => unknown
   readonly render: () => readonly VirtualDomNode[] | Promise<readonly VirtualDomNode[]>
+  readonly renderFocus?: (oldContext: Readonly<Record<string, boolean>>, newContext: Readonly<Record<string, boolean>>) => string | Promise<string>
   readonly saveState?: () => unknown
 }
 
@@ -71,10 +72,12 @@ export interface ViewRegistrySnapshot {
 
 export interface ViewRenderResultDom {
   readonly dom: readonly VirtualDomNode[]
+  readonly focusSelector?: string
   readonly type: 'setDom'
 }
 
 export interface ViewRenderResultPatches {
+  readonly focusSelector?: string
   readonly patches: readonly unknown[]
   readonly type: 'setPatches'
 }

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -20,6 +20,12 @@ const renderedDoms: Record<number, readonly VirtualDomNode[]> = Object.create(nu
 const contexts: Record<number, Readonly<Record<string, boolean>>> = Object.create(null)
 const contextViewIds: Record<number, string> = Object.create(null)
 
+interface ContextChange {
+  readonly changed: boolean
+  readonly newContext: Readonly<Record<string, boolean>>
+  readonly oldContext: Readonly<Record<string, boolean>>
+}
+
 const assertBoolean = (value: unknown, message: string): void => {
   if (value !== undefined && typeof value !== 'boolean') {
     throw new ExtensionApiError(message)
@@ -213,14 +219,24 @@ const isSameContext = (oldContext: Readonly<Record<string, boolean>>, newContext
   return true
 }
 
-const maybeNotifyContextChanged = async (uid: number, viewId: string, instance: VirtualDomViewInstance): Promise<void> => {
+const unchangedContext: ContextChange = {
+  changed: false,
+  newContext: {},
+  oldContext: {},
+}
+
+const maybeNotifyContextChanged = async (uid: number, viewId: string, instance: VirtualDomViewInstance): Promise<ContextChange> => {
   if (typeof instance.getContext !== 'function') {
-    return
+    return unchangedContext
   }
   const oldContext = contexts[uid] || {}
   const newContext = normalizeContext(instance.getContext())
   if (isSameContext(oldContext, newContext)) {
-    return
+    return {
+      changed: false,
+      newContext,
+      oldContext,
+    }
   }
   if (Object.keys(newContext).length === 0) {
     delete contexts[uid]
@@ -228,6 +244,37 @@ const maybeNotifyContextChanged = async (uid: number, viewId: string, instance: 
     contexts[uid] = newContext
   }
   await ExtensionManagementWorker.invoke('Extensions.handleViewContextChange', uid, viewId, newContext)
+  return {
+    changed: true,
+    newContext,
+    oldContext,
+  }
+}
+
+const renderFocus = async (instance: VirtualDomViewInstance, contextChange: ContextChange): Promise<string> => {
+  if (!contextChange.changed || typeof instance.renderFocus !== 'function') {
+    return ''
+  }
+  const focusSelector = await instance.renderFocus(contextChange.oldContext, contextChange.newContext)
+  if (typeof focusSelector !== 'string') {
+    throw new ExtensionApiError('view renderFocus result must be a string')
+  }
+  return focusSelector
+}
+
+const withFocusSelector = async (
+  result: ViewRenderResult,
+  instance: VirtualDomViewInstance,
+  contextChange: ContextChange,
+): Promise<ViewRenderResult> => {
+  const focusSelector = await renderFocus(instance, contextChange)
+  if (!focusSelector) {
+    return result
+  }
+  return {
+    ...result,
+    focusSelector,
+  }
 }
 
 const maybeClearContext = async (uid: number, viewId: string): Promise<void> => {
@@ -265,11 +312,12 @@ export const createViewInstance = async (viewId: string, uid: number, context?: 
   contextViewIds[uid] = viewId
   const dom = await renderDom(instance)
   renderedDoms[uid] = dom
-  await maybeNotifyContextChanged(uid, viewId, instance)
-  return {
+  const result: ViewRenderResult = {
     dom,
     type: 'setDom',
   }
+  const contextChange = await maybeNotifyContextChanged(uid, viewId, instance)
+  return withFocusSelector(result, instance, contextChange)
 }
 
 export const dispatchViewEvent = async (uid: number, event: ViewEvent): Promise<ViewRenderResult> => {
@@ -278,15 +326,15 @@ export const dispatchViewEvent = async (uid: number, event: ViewEvent): Promise<
     await instance.handleEvent(event)
   }
   const result = await renderPatches(uid, instance)
-  await maybeNotifyContextChanged(uid, contextViewIds[uid], instance)
-  return result
+  const contextChange = await maybeNotifyContextChanged(uid, contextViewIds[uid], instance)
+  return withFocusSelector(result, instance, contextChange)
 }
 
 export const renderViewInstance = async (uid: number): Promise<ViewRenderResult> => {
   const instance = getVirtualDomInstance(uid)
   const result = await renderPatches(uid, instance)
-  await maybeNotifyContextChanged(uid, contextViewIds[uid], instance)
-  return result
+  const contextChange = await maybeNotifyContextChanged(uid, contextViewIds[uid], instance)
+  return withFocusSelector(result, instance, contextChange)
 }
 
 export const disposeViewInstance = async (uid: number): Promise<void> => {

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -374,6 +374,118 @@ test('view context changes are reported after lifecycle updates', async () => {
   ])
 })
 
+test('renderFocus is included after context changes', async () => {
+  const contextInvocations: unknown[] = []
+  const focusInvocations: unknown[] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleViewContextChange'(uid: number, viewId: string, context: Readonly<Record<string, boolean>>): Promise<void> {
+      contextInvocations.push([uid, viewId, context])
+    },
+  })
+  let focused = true
+  registerView({
+    create() {
+      return {
+        getContext() {
+          return focused ? { 'sample.focus': true } : { 'sample.nextFocus': true }
+        },
+        handleEvent() {
+          focused = false
+        },
+        render() {
+          return []
+        },
+        renderFocus(oldContext: Readonly<Record<string, boolean>>, newContext: Readonly<Record<string, boolean>>) {
+          focusInvocations.push([oldContext, newContext])
+          if (newContext['sample.focus']) {
+            return '[name="first"]'
+          }
+          return '[name="next"]'
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  deepStrictEqual(await createViewInstance('sample.views.testing', 1), {
+    dom: [],
+    focusSelector: '[name="first"]',
+    type: 'setDom',
+  })
+  deepStrictEqual(await renderViewInstance(1), {
+    patches: [],
+    type: 'setPatches',
+  })
+  deepStrictEqual(await dispatchViewEvent(1, { type: 'click' }), {
+    focusSelector: '[name="next"]',
+    patches: [],
+    type: 'setPatches',
+  })
+
+  deepStrictEqual(contextInvocations, [
+    [1, 'sample.views.testing', { 'sample.focus': true }],
+    [1, 'sample.views.testing', { 'sample.nextFocus': true }],
+  ])
+  deepStrictEqual(focusInvocations, [
+    [{}, { 'sample.focus': true }],
+    [{ 'sample.focus': true }, { 'sample.nextFocus': true }],
+  ])
+})
+
+test('renderFocus empty selector is omitted', async () => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleViewContextChange'(): Promise<void> {},
+  })
+  registerView({
+    create() {
+      return {
+        getContext() {
+          return { 'sample.focus': true }
+        },
+        render() {
+          return []
+        },
+        renderFocus() {
+          return ''
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  deepStrictEqual(await createViewInstance('sample.views.testing', 1), {
+    dom: [],
+    type: 'setDom',
+  })
+})
+
+test('renderFocus rejects non-string results', async () => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleViewContextChange'(): Promise<void> {},
+  })
+  registerView({
+    create() {
+      return {
+        getContext() {
+          return { 'sample.focus': true }
+        },
+        render() {
+          return []
+        },
+        renderFocus() {
+          return 42 as any
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await rejects(createViewInstance('sample.views.testing', 1), /view renderFocus result must be a string/)
+})
+
 test('saveViewInstanceState returns instance state', async () => {
   registerView({
     create() {


### PR DESCRIPTION
## Summary
- add extension view renderFocus support and focus selectors on render results
- call renderFocus when view context changes
- cover context-driven focus behavior in ViewRegistry tests

## Validation
- npm test
- npm run type-check