### PR TITLE
fix: expose provider readonly capability

### DIFF
--- a/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
@@ -104,6 +104,7 @@ export const commandMap: Record<string, CommandHandler> = {
   [ExtensionHostCommandType.DiagnosticExecuteDiagnosticProvider]: ExtensionHostDiagnostic.executeDiagnosticProvider,
   [ExtensionHostCommandType.ExtensionActivate]: ExtensionHostExtension.activateExtension,
   [ExtensionHostCommandType.FileSystemGetPathSeparator]: ExtensionHostFileSystem.getPathSeparator,
+  [ExtensionHostCommandType.FileSystemIsReadonly]: ExtensionHostFileSystem.isReadonly,
   [ExtensionHostCommandType.FileSystemMkdir]: ExtensionHostFileSystem.mkdir,
   [ExtensionHostCommandType.FileSystemReadDirWithFileTypes]: ExtensionHostFileSystem.readDirWithFileTypes,
   [ExtensionHostCommandType.FileSystemReadFile]: ExtensionHostFileSystem.readFile,

--- a/packages/extension-host-worker/src/parts/ExtensionHostCommandType/ExtensionHostCommandType.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostCommandType/ExtensionHostCommandType.ts
@@ -9,6 +9,7 @@ export const DefinitionExecuteDefinitionProvider = 'ExtensionHostDefinition.exec
 export const DiagnosticExecuteDiagnosticProvider = 'ExtensionHost.executeDiagnosticProvider'
 export const ExtensionActivate = 'ExtensionHostExtension.activate'
 export const FileSystemGetPathSeparator = 'ExtensionHostFileSystem.getPathSeparator'
+export const FileSystemIsReadonly = 'ExtensionHostFileSystem.isReadonly'
 export const FileSystemMkdir = 'ExtensionHostFileSystem.mkdir'
 export const FileSystemReadDirWithFileTypes = 'ExtensionHostFileSystem.readDirWithFileTypes'
 export const FileSystemReadFile = 'ExtensionHostFileSystem.readFile'

--- a/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
@@ -123,3 +123,15 @@ export const getPathSeparator = (protocol) => {
     throw new VError(error, 'Failed to execute file system provider')
   }
 }
+
+export const isReadonly = async (protocol) => {
+  try {
+    const provider = FileSystemProviderState.get(protocol)
+    if (!provider.isReadonly) {
+      return false
+    }
+    return await provider.isReadonly()
+  } catch (error) {
+    throw new VError(error, 'Failed to execute file system provider')
+  }
+}

--- a/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
@@ -181,7 +181,5 @@ test('isReadonly - when file system provider throws error', async () => {
       throw new Error('x is not a function')
     },
   })
-  await expect(ExtensionHostFileSystem.isReadonly('memfs')).rejects.toThrow(
-    new Error('Failed to execute file system provider: x is not a function'),
-  )
+  await expect(ExtensionHostFileSystem.isReadonly('memfs')).rejects.toThrow(new Error('Failed to execute file system provider: x is not a function'))
 })

--- a/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
@@ -156,3 +156,32 @@ test('getPathSeparator - backslash', () => {
   })
   expect(ExtensionHostFileSystem.getPathSeparator('memfs')).toBe('\\')
 })
+
+test('isReadonly - default false', async () => {
+  ExtensionHostFileSystem.registerFileSystemProvider({
+    id: 'memfs',
+  })
+  await expect(ExtensionHostFileSystem.isReadonly('memfs')).resolves.toBe(false)
+})
+
+test('isReadonly', async () => {
+  ExtensionHostFileSystem.registerFileSystemProvider({
+    id: 'memfs',
+    isReadonly() {
+      return true
+    },
+  })
+  await expect(ExtensionHostFileSystem.isReadonly('memfs')).resolves.toBe(true)
+})
+
+test('isReadonly - when file system provider throws error', async () => {
+  ExtensionHostFileSystem.registerFileSystemProvider({
+    id: 'memfs',
+    isReadonly() {
+      throw new Error('x is not a function')
+    },
+  })
+  await expect(ExtensionHostFileSystem.isReadonly('memfs')).rejects.toThrow(
+    new Error('Failed to execute file system provider: x is not a function'),
+  )
+})


### PR DESCRIPTION
Summary:\n- add ExtensionHostFileSystem.isReadonly provider command\n- default providers to writable unless they implement isReadonly