### PR TITLE
feature: extend isolated extension api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -22,7 +22,8 @@ export {
   registerFormattingProvider,
   resetFormattingProviderRegistry,
 } from './parts/Formatting/Formatting.ts'
-export { exists, mkdir, readDirWithFileTypes, readFile, remove, writeFile } from './parts/FileSystem/FileSystem.ts'
+export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
+export { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export {
   executeSourceControlAcceptInput,
@@ -70,6 +71,7 @@ export type {
   VirtualDomViewInstance,
 } from './parts/View/View.ts'
 export { handleExtensionManagementMessagePort } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
+export { createNodeRpc, createRpc } from './parts/Rpc/Rpc.ts'
 export type { Command } from './parts/Command/Command.ts'
 export type { CommandCallback } from './parts/CommandCallback/CommandCallback.ts'
 export type { CommandRegistrySnapshot } from './parts/CommandRegistrySnapshot/CommandRegistrySnapshot.ts'
@@ -99,6 +101,7 @@ export type { OutputChannel } from './parts/OutputChannelHandle/OutputChannelHan
 export type { OutputChannelRegistrySnapshot } from './parts/OutputChannelRegistrySnapshot/OutputChannelRegistrySnapshot.ts'
 export type { RegisteredOutputChannel } from './parts/RegisteredOutputChannel/RegisteredOutputChannel.ts'
 export type { QuickPickItem } from './parts/QuickPickItem/QuickPickItem.ts'
+export type { CreateNodeRpcOptions, CreateRpcOptions } from './parts/Rpc/Rpc.ts'
 export type {
   RegisteredSourceControlProvider,
   SourceControlProvider,

--- a/packages/extension-api/src/parts/FileSystem/FileSystem.ts
+++ b/packages/extension-api/src/parts/FileSystem/FileSystem.ts
@@ -30,6 +30,10 @@ export const remove = async (uri: string): Promise<void> => {
   await FileSystemWorker.remove(uri)
 }
 
+export const stat = async (uri: string): Promise<unknown> => {
+  return FileSystemWorker.stat(uri)
+}
+
 export const writeFile = async (uri: string, content: string): Promise<void> => {
   await FileSystemWorker.writeFile(uri, content)
 }

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -1,0 +1,17 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export const confirm = async (message: string): Promise<boolean> => {
+  return Boolean(await executeCommand('ConfirmPrompt.prompt', message))
+}
+
+export const getWorkspaceFolder = async (): Promise<string> => {
+  return (await executeCommand('Workspace.getPath')) as string
+}
+
+export const handleWorkspaceRefresh = async (): Promise<void> => {
+  await executeCommand('Layout.handleWorkspaceRefresh')
+}
+
+export const openUri = async (uri: string): Promise<void> => {
+  await executeCommand('Main.openUri', uri)
+}

--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -1,0 +1,38 @@
+import { LazyTransferMessagePortRpcParent, ModuleWorkerRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+export interface CreateRpcOptions {
+  readonly commandMap?: Record<string, unknown>
+  readonly name?: string
+  readonly url: string
+}
+
+export interface CreateNodeRpcOptions {
+  readonly name?: string
+  readonly path: string
+}
+
+const sendMessagePortToNode = async (port: MessagePort): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer(
+    'Extensions.sendMessagePortToElectron',
+    port,
+    'HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess',
+  )
+}
+
+export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOptions): Promise<Rpc> => {
+  return ModuleWorkerRpcParent.create({
+    commandMap,
+    name,
+    url,
+  })
+}
+
+export const createNodeRpc = async ({ path }: CreateNodeRpcOptions): Promise<Rpc> => {
+  const rpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: sendMessagePortToNode,
+  })
+  await rpc.invoke('LoadFile.loadFile', path)
+  return rpc
+}

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker, FileSystemWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { exists, mkdir, readDirWithFileTypes, readFile, remove, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
+import { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -106,6 +106,25 @@ test('remove deletes through the file system worker', async () => {
 
   await remove('/tmp/sample.txt')
 
+  strictEqual(invokedUri, '/tmp/sample.txt')
+})
+
+test('stat reads file metadata through the file system worker', async () => {
+  let invokedUri = ''
+  const stats = {
+    isDirectory: false,
+    size: 42,
+  }
+  mockRpc = FileSystemWorker.registerMockRpc({
+    async 'FileSystem.stat'(uri: string): Promise<unknown> {
+      invokedUri = uri
+      return stats
+    },
+  })
+
+  const result = await stat('/tmp/sample.txt')
+
+  deepStrictEqual(result, stats)
   strictEqual(invokedUri, '/tmp/sample.txt')
 })
 

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -1,0 +1,43 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from '../../../src/parts/Host/Host.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('host helpers execute renderer commands through extension management', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      if (id === 'Workspace.getPath') {
+        return '/workspace'
+      }
+      if (id === 'ConfirmPrompt.prompt') {
+        return true
+      }
+      return undefined
+    },
+  })
+
+  strictEqual(await getWorkspaceFolder(), '/workspace')
+  strictEqual(await confirm('Discard changes?'), true)
+  await handleWorkspaceRefresh()
+  await openUri('/workspace/file.txt')
+
+  deepStrictEqual(invocations, [
+    ['Workspace.getPath'],
+    ['ConfirmPrompt.prompt', 'Discard changes?'],
+    ['Layout.handleWorkspaceRefresh'],
+    ['Main.openUri', '/workspace/file.txt'],
+  ])
+})

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -1,0 +1,43 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createNodeRpc } from '../../../src/parts/Rpc/Rpc.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('createNodeRpc transfers a port and loads the requested file', async () => {
+  const invocations: string[] = []
+  let loadedPath = ''
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.sendMessagePortToElectron'(port: MessagePort, initialCommand: string): Promise<void> {
+      invocations.push(initialCommand)
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'LoadFile.loadFile'(path: string): void {
+            loadedPath = path
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+
+  const rpc = await createNodeRpc({
+    name: 'Git',
+    path: '/extensions/git/node/gitClient.js',
+  })
+
+  strictEqual(loadedPath, '/extensions/git/node/gitClient.js')
+  deepStrictEqual(invocations, ['HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess'])
+  await rpc.dispose()
+})


### PR DESCRIPTION
Add the host, filesystem metadata, web-worker RPC, and Node-helper RPC APIs needed by isolated extensions such as the built-in Git integration.