### PR TITLE
fix: create extension web worker rpc through host

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -22,7 +22,8 @@ export {
   registerFormattingProvider,
   resetFormattingProviderRegistry,
 } from './parts/Formatting/Formatting.ts'
-export { exists, mkdir, readDirWithFileTypes, readFile, remove, writeFile } from './parts/FileSystem/FileSystem.ts'
+export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
+export { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export {
   executeSourceControlAcceptInput,
@@ -70,6 +71,7 @@ export type {
   VirtualDomViewInstance,
 } from './parts/View/View.ts'
 export { handleExtensionManagementMessagePort } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
+export { createNodeRpc, createRpc } from './parts/Rpc/Rpc.ts'
 export type { Command } from './parts/Command/Command.ts'
 export type { CommandCallback } from './parts/CommandCallback/CommandCallback.ts'
 export type { CommandRegistrySnapshot } from './parts/CommandRegistrySnapshot/CommandRegistrySnapshot.ts'
@@ -99,6 +101,7 @@ export type { OutputChannel } from './parts/OutputChannelHandle/OutputChannelHan
 export type { OutputChannelRegistrySnapshot } from './parts/OutputChannelRegistrySnapshot/OutputChannelRegistrySnapshot.ts'
 export type { RegisteredOutputChannel } from './parts/RegisteredOutputChannel/RegisteredOutputChannel.ts'
 export type { QuickPickItem } from './parts/QuickPickItem/QuickPickItem.ts'
+export type { CreateNodeRpcOptions, CreateRpcOptions } from './parts/Rpc/Rpc.ts'
 export type {
   RegisteredSourceControlProvider,
   SourceControlProvider,

--- a/packages/extension-api/src/parts/FileSystem/FileSystem.ts
+++ b/packages/extension-api/src/parts/FileSystem/FileSystem.ts
@@ -30,6 +30,10 @@ export const remove = async (uri: string): Promise<void> => {
   await FileSystemWorker.remove(uri)
 }
 
+export const stat = async (uri: string): Promise<unknown> => {
+  return FileSystemWorker.stat(uri)
+}
+
 export const writeFile = async (uri: string, content: string): Promise<void> => {
   await FileSystemWorker.writeFile(uri, content)
 }

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -1,0 +1,17 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export const confirm = async (message: string): Promise<boolean> => {
+  return Boolean(await executeCommand('ConfirmPrompt.prompt', message))
+}
+
+export const getWorkspaceFolder = async (): Promise<string> => {
+  return (await executeCommand('Workspace.getPath')) as string
+}
+
+export const handleWorkspaceRefresh = async (): Promise<void> => {
+  await executeCommand('Layout.handleWorkspaceRefresh')
+}
+
+export const openUri = async (uri: string): Promise<void> => {
+  await executeCommand('Main.openUri', uri)
+}

--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -1,0 +1,38 @@
+import { LazyTransferMessagePortRpcParent, ModuleWorkerRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+export interface CreateRpcOptions {
+  readonly commandMap?: Record<string, unknown>
+  readonly name?: string
+  readonly url: string
+}
+
+export interface CreateNodeRpcOptions {
+  readonly name?: string
+  readonly path: string
+}
+
+const sendMessagePortToNode = async (port: MessagePort): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer(
+    'Extensions.sendMessagePortToElectron',
+    port,
+    'HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess',
+  )
+}
+
+export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOptions): Promise<Rpc> => {
+  return ModuleWorkerRpcParent.create({
+    commandMap,
+    name,
+    url,
+  })
+}
+
+export const createNodeRpc = async ({ path }: CreateNodeRpcOptions): Promise<Rpc> => {
+  const rpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: sendMessagePortToNode,
+  })
+  await rpc.invoke('LoadFile.loadFile', path)
+  return rpc
+}

--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -1,4 +1,4 @@
-import { LazyTransferMessagePortRpcParent, ModuleWorkerRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { LazyTransferMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
 export interface CreateRpcOptions {
@@ -20,12 +20,19 @@ const sendMessagePortToNode = async (port: MessagePort): Promise<void> => {
   )
 }
 
+const sendMessagePortToWebWorker = async (port: MessagePort, name: string): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer('Extensions.createWebViewWorkerRpc', { name }, port)
+}
+
 export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOptions): Promise<Rpc> => {
-  return ModuleWorkerRpcParent.create({
+  const rpc = await LazyTransferMessagePortRpcParent.create({
     commandMap,
-    name,
-    url,
+    send(port): Promise<void> {
+      return sendMessagePortToWebWorker(port, name)
+    },
   })
+  await rpc.invoke('LoadFile.loadFile', url)
+  return rpc
 }
 
 export const createNodeRpc = async ({ path }: CreateNodeRpcOptions): Promise<Rpc> => {

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker, FileSystemWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { exists, mkdir, readDirWithFileTypes, readFile, remove, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
+import { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -106,6 +106,25 @@ test('remove deletes through the file system worker', async () => {
 
   await remove('/tmp/sample.txt')
 
+  strictEqual(invokedUri, '/tmp/sample.txt')
+})
+
+test('stat reads file metadata through the file system worker', async () => {
+  let invokedUri = ''
+  const stats = {
+    isDirectory: false,
+    size: 42,
+  }
+  mockRpc = FileSystemWorker.registerMockRpc({
+    async 'FileSystem.stat'(uri: string): Promise<unknown> {
+      invokedUri = uri
+      return stats
+    },
+  })
+
+  const result = await stat('/tmp/sample.txt')
+
+  deepStrictEqual(result, stats)
   strictEqual(invokedUri, '/tmp/sample.txt')
 })
 

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -1,0 +1,43 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from '../../../src/parts/Host/Host.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('host helpers execute renderer commands through extension management', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      if (id === 'Workspace.getPath') {
+        return '/workspace'
+      }
+      if (id === 'ConfirmPrompt.prompt') {
+        return true
+      }
+      return undefined
+    },
+  })
+
+  strictEqual(await getWorkspaceFolder(), '/workspace')
+  strictEqual(await confirm('Discard changes?'), true)
+  await handleWorkspaceRefresh()
+  await openUri('/workspace/file.txt')
+
+  deepStrictEqual(invocations, [
+    ['Workspace.getPath'],
+    ['ConfirmPrompt.prompt', 'Discard changes?'],
+    ['Layout.handleWorkspaceRefresh'],
+    ['Main.openUri', '/workspace/file.txt'],
+  ])
+})

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -1,0 +1,43 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createNodeRpc } from '../../../src/parts/Rpc/Rpc.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('createNodeRpc transfers a port and loads the requested file', async () => {
+  const invocations: string[] = []
+  let loadedPath = ''
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.sendMessagePortToElectron'(port: MessagePort, initialCommand: string): Promise<void> {
+      invocations.push(initialCommand)
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'LoadFile.loadFile'(path: string): void {
+            loadedPath = path
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+
+  const rpc = await createNodeRpc({
+    name: 'Git',
+    path: '/extensions/git/node/gitClient.js',
+  })
+
+  strictEqual(loadedPath, '/extensions/git/node/gitClient.js')
+  deepStrictEqual(invocations, ['HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess'])
+  await rpc.dispose()
+})

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -2,7 +2,7 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { createNodeRpc } from '../../../src/parts/Rpc/Rpc.ts'
+import { createNodeRpc, createRpc } from '../../../src/parts/Rpc/Rpc.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -39,5 +39,33 @@ test('createNodeRpc transfers a port and loads the requested file', async () => 
 
   strictEqual(loadedPath, '/extensions/git/node/gitClient.js')
   deepStrictEqual(invocations, ['HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess'])
+  await rpc.dispose()
+})
+
+test('createRpc transfers a port and loads the requested file', async () => {
+  const invocations: unknown[] = []
+  let loadedUrl = ''
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.createWebViewWorkerRpc'(rpcInfo: unknown, port: MessagePort): Promise<void> {
+      invocations.push(rpcInfo)
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'LoadFile.loadFile'(url: string): void {
+            loadedUrl = url
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+
+  const rpc = await createRpc({
+    commandMap: {},
+    name: 'Git Worker',
+    url: '/extensions/git/gitWorkerMain.js',
+  })
+
+  strictEqual(loadedUrl, '/extensions/git/gitWorkerMain.js')
+  deepStrictEqual(invocations, [{ name: 'Git Worker' }])
   await rpc.dispose()
 })


### PR DESCRIPTION
## Summary
- create extension web worker RPCs through the existing extension-management MessagePort bridge
- load worker command maps through the host subworker, matching the legacy extension API contract
- cover MessagePort transfer and worker module loading

## Validation
- extension API tests (129 passed)
- extension API type-check
- repository lint