### PR TITLE
fix: create extension web worker rpc through host

### DIFF
--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -1,4 +1,4 @@
-import { LazyTransferMessagePortRpcParent, ModuleWorkerRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { LazyTransferMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
 export interface CreateRpcOptions {
@@ -20,12 +20,19 @@ const sendMessagePortToNode = async (port: MessagePort): Promise<void> => {
   )
 }
 
+const sendMessagePortToWebWorker = async (port: MessagePort, name: string): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer('Extensions.createWebViewWorkerRpc', { name }, port)
+}
+
 export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOptions): Promise<Rpc> => {
-  return ModuleWorkerRpcParent.create({
+  const rpc = await LazyTransferMessagePortRpcParent.create({
     commandMap,
-    name,
-    url,
+    send(port): Promise<void> {
+      return sendMessagePortToWebWorker(port, name)
+    },
   })
+  await rpc.invoke('LoadFile.loadFile', url)
+  return rpc
 }
 
 export const createNodeRpc = async ({ path }: CreateNodeRpcOptions): Promise<Rpc> => {

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -2,7 +2,7 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { createNodeRpc } from '../../../src/parts/Rpc/Rpc.ts'
+import { createNodeRpc, createRpc } from '../../../src/parts/Rpc/Rpc.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -39,5 +39,33 @@ test('createNodeRpc transfers a port and loads the requested file', async () => 
 
   strictEqual(loadedPath, '/extensions/git/node/gitClient.js')
   deepStrictEqual(invocations, ['HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess'])
+  await rpc.dispose()
+})
+
+test('createRpc transfers a port and loads the requested file', async () => {
+  const invocations: unknown[] = []
+  let loadedUrl = ''
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.createWebViewWorkerRpc'(rpcInfo: unknown, port: MessagePort): Promise<void> {
+      invocations.push(rpcInfo)
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'LoadFile.loadFile'(url: string): void {
+            loadedUrl = url
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+
+  const rpc = await createRpc({
+    commandMap: {},
+    name: 'Git Worker',
+    url: '/extensions/git/gitWorkerMain.js',
+  })
+
+  strictEqual(loadedUrl, '/extensions/git/gitWorkerMain.js')
+  deepStrictEqual(invocations, [{ name: 'Git Worker' }])
   await rpc.dispose()
 })


### PR DESCRIPTION
## Summary
- create extension web worker RPCs through the existing extension-management MessagePort bridge
- load worker command maps through the host subworker, matching the legacy extension API contract
- cover MessagePort transfer and worker module loading

## Validation
- extension API tests (129 passed)
- extension API type-check
- repository lint