### PR TITLE
Expose isolated source actions

### DIFF
--- a/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
@@ -93,6 +93,7 @@ export const commandMap: Record<string, CommandHandler> = {
   'ExtensionHost.importExtension': ImportExtension.importExtension,
   'ExtensionHost.importExtension2': importExtension2,
   'ExtensionHost.launchIframeWorker': LaunchIframeWorker.launchIframeWorker,
+  'ExtensionHostCodeActions.getSourceActions': ExtensionHostCodeActions.getSourceActions,
   [ExtensionHostCommandType.BraceCompletionExecuteBraceCompletionProvider]: ExtensionHostBraceCompletion.executeBraceCompletionProvider,
   [ExtensionHostCommandType.ClosingTagExecuteClosingTagProvider]: ExtensionHostClosingTag.executeClosingTagProvider,
   [ExtensionHostCommandType.CommandExecute]: ExtensionHostCommand.executeCommand,

--- a/packages/extension-host-worker/src/parts/ExtensionHostCodeActions/ExtensionHostCodeActions.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostCodeActions/ExtensionHostCodeActions.ts
@@ -3,7 +3,12 @@ import * as ExtensionHostTextDocument from '../ExtensionHostTextDocument/Extensi
 import * as Registry from '../Registry/Registry.ts'
 import * as Types from '../Types/Types.ts'
 
-const { executeCodeActionProvider, getProvider, registerCodeActionProvider } = Registry.create({
+const {
+  executeCodeActionProvider: executeRegisteredCodeActionProvider,
+  getProvider,
+  registerCodeActionProvider,
+  reset,
+} = Registry.create({
   name: 'CodeAction',
   resultShape: {
     items: {
@@ -13,7 +18,39 @@ const { executeCodeActionProvider, getProvider, registerCodeActionProvider } = R
   },
 })
 
-export { registerCodeActionProvider }
+export { registerCodeActionProvider, reset }
+
+interface CodeAction {
+  readonly kind: string
+  readonly name: string
+}
+
+const executeCodeActionProvider = async (uid): Promise<readonly CodeAction[]> => {
+  if (!ExecuteIsolatedLanguageProvider.hasLegacyProvider(getProvider, uid)) {
+    const isolated = await ExecuteIsolatedLanguageProvider.execute('code action', 'provideCodeActions', uid)
+    if (isolated.found) {
+      return isolated.result as readonly CodeAction[]
+    }
+  }
+  return (await executeRegisteredCodeActionProvider(uid)) as unknown as readonly CodeAction[]
+}
+
+const toSourceAction = (languageId: string, action: CodeAction) => {
+  return {
+    kind: action.kind,
+    languageId,
+    name: action.name,
+  }
+}
+
+export const getSourceActions = async (uid) => {
+  const textDocument = ExtensionHostTextDocument.get(uid)
+  if (!textDocument) {
+    return []
+  }
+  const actions = await executeCodeActionProvider(uid)
+  return actions.map((action) => toSourceAction(textDocument.languageId, action))
+}
 
 const isOrganizeImports = (action) => {
   return action.kind === 'source.organizeImports'
@@ -27,7 +64,7 @@ export const executeOrganizeImports = async (uid) => {
       return isolated.result
     }
   }
-  const actions = await executeCodeActionProvider(uid)
+  const actions = await executeRegisteredCodeActionProvider(uid)
   // @ts-ignore
   if (!actions || actions.length === 0) {
     return []

--- a/packages/extension-host-worker/test/ExtensionHostCodeActions.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostCodeActions.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const executeMock = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+
+jest.unstable_mockModule('../src/parts/ExecuteIsolatedLanguageProvider/ExecuteIsolatedLanguageProvider.ts', () => ({
+  execute: executeMock,
+  executeOrganizeImports: jest.fn(),
+  hasLegacyProvider: (getProvider: (languageId: string) => unknown, textDocumentId: number) => {
+    return Boolean(getProvider(TextDocument.get(textDocumentId)?.languageId))
+  },
+}))
+
+const ExtensionHostCodeActions = await import('../src/parts/ExtensionHostCodeActions/ExtensionHostCodeActions.ts')
+const TextDocument = await import('../src/parts/ExtensionHostTextDocument/ExtensionHostTextDocument.ts')
+
+beforeEach(() => {
+  ExtensionHostCodeActions.reset()
+  executeMock.mockReset()
+})
+
+test('getSourceActions returns serializable legacy code actions', async () => {
+  TextDocument.setFiles([
+    {
+      id: 1,
+      languageId: 'typescript',
+      text: '',
+      uri: 'file:///test.ts',
+    },
+  ])
+  ExtensionHostCodeActions.registerCodeActionProvider({
+    languageId: 'typescript',
+    provideCodeActions() {
+      return [
+        {
+          execute() {},
+          kind: 'source.organizeImports',
+          name: 'Organize Imports',
+        },
+      ]
+    },
+  })
+
+  await expect(ExtensionHostCodeActions.getSourceActions(1)).resolves.toEqual([
+    {
+      kind: 'source.organizeImports',
+      languageId: 'typescript',
+      name: 'Organize Imports',
+    },
+  ])
+  expect(executeMock).not.toHaveBeenCalled()
+})
+
+test('getSourceActions returns serializable isolated code actions', async () => {
+  TextDocument.setFiles([
+    {
+      id: 2,
+      languageId: 'typescript',
+      text: '',
+      uri: 'file:///test.ts',
+    },
+  ])
+  executeMock.mockResolvedValue({
+    found: true,
+    result: [
+      {
+        kind: 'source.organizeImports',
+        name: 'Organize Imports',
+      },
+    ],
+  })
+
+  await expect(ExtensionHostCodeActions.getSourceActions(2)).resolves.toEqual([
+    {
+      kind: 'source.organizeImports',
+      languageId: 'typescript',
+      name: 'Organize Imports',
+    },
+  ])
+  expect(executeMock).toHaveBeenCalledWith('code action', 'provideCodeActions', 2)
+})
+
+test('getSourceActions returns an empty array for a missing text document', async () => {
+  await expect(ExtensionHostCodeActions.getSourceActions(999)).resolves.toEqual([])
+  expect(executeMock).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Exposes serializable code-action metadata for both legacy and isolated language providers so editor source-action widgets can load TypeScript actions.