### PR TITLE
fix: handle uncaught isolated extension errors

### DIFF
--- a/packages/extension-api/src/parts/ExtensionApiWorkerListen/ExtensionApiWorkerListen.ts
+++ b/packages/extension-api/src/parts/ExtensionApiWorkerListen/ExtensionApiWorkerListen.ts
@@ -1,7 +1,11 @@
 import { type Rpc, WebWorkerRpcClient } from '@lvce-editor/rpc'
 import * as ExtensionApiWorkerCommandMap from '../ExtensionApiWorkerCommandMap/ExtensionApiWorkerCommandMap.ts'
+import * as HandleUnhandledError from '../HandleUnhandledError/HandleUnhandledError.ts'
+import * as HandleUnhandledRejection from '../HandleUnhandledRejection/HandleUnhandledRejection.ts'
 
 export const listen = async (): Promise<Rpc> => {
+  globalThis.addEventListener('error', HandleUnhandledError.handleUnhandledError)
+  globalThis.addEventListener('unhandledrejection', HandleUnhandledRejection.handleUnhandledRejection)
   const rpc = WebWorkerRpcClient.create({
     commandMap: ExtensionApiWorkerCommandMap.commandMap,
   })

--- a/packages/extension-api/src/parts/HandleUncaughtExtensionError/HandleUncaughtExtensionError.ts
+++ b/packages/extension-api/src/parts/HandleUncaughtExtensionError/HandleUncaughtExtensionError.ts
@@ -1,0 +1,7 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import * as SerializeError from '../SerializeError/SerializeError.ts'
+
+export const handleUncaughtExtensionError = async (error: unknown): Promise<void> => {
+  const serializedError = SerializeError.serializeError(error)
+  await ExtensionManagementWorker.invoke('Extensions.handleUncaughtExtensionError', serializedError)
+}

--- a/packages/extension-api/src/parts/HandleUnhandledError/HandleUnhandledError.ts
+++ b/packages/extension-api/src/parts/HandleUnhandledError/HandleUnhandledError.ts
@@ -1,0 +1,24 @@
+import * as HandleUncaughtExtensionError from '../HandleUncaughtExtensionError/HandleUncaughtExtensionError.ts'
+
+const getError = (event: ErrorEvent): unknown => {
+  if (event.error) {
+    return event.error
+  }
+  return {
+    constructor: {
+      name: 'Error',
+    },
+    message: event.message,
+    stack: `${event.message}\n    at ${event.filename}:${event.lineno}:${event.colno}`,
+  }
+}
+
+export const handleUnhandledError = async (event: ErrorEvent): Promise<void> => {
+  event.preventDefault()
+  const error = getError(event)
+  try {
+    await HandleUncaughtExtensionError.handleUncaughtExtensionError(error)
+  } catch {
+    console.error(error)
+  }
+}

--- a/packages/extension-api/src/parts/HandleUnhandledRejection/HandleUnhandledRejection.ts
+++ b/packages/extension-api/src/parts/HandleUnhandledRejection/HandleUnhandledRejection.ts
@@ -1,0 +1,10 @@
+import * as HandleUncaughtExtensionError from '../HandleUncaughtExtensionError/HandleUncaughtExtensionError.ts'
+
+export const handleUnhandledRejection = async (event: PromiseRejectionEvent): Promise<void> => {
+  event.preventDefault()
+  try {
+    await HandleUncaughtExtensionError.handleUncaughtExtensionError(event.reason)
+  } catch {
+    console.error(event.reason)
+  }
+}

--- a/packages/extension-api/src/parts/SerializeError/SerializeError.ts
+++ b/packages/extension-api/src/parts/SerializeError/SerializeError.ts
@@ -1,0 +1,31 @@
+export interface SerializedError {
+  readonly code?: unknown
+  readonly codeFrame?: unknown
+  readonly constructor: {
+    readonly name: string
+  }
+  readonly message?: unknown
+  readonly name?: unknown
+  readonly stack?: unknown
+}
+
+const getConstructorName = (error: Record<string, any>): string => {
+  return error.constructor?.name || 'Error'
+}
+
+export const serializeError = (error: unknown): SerializedError | unknown => {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+    return error
+  }
+  const value = error as Record<string, any>
+  return {
+    code: value.code,
+    codeFrame: value.codeFrame,
+    constructor: {
+      name: getConstructorName(value),
+    },
+    message: value.message,
+    name: value.name,
+    stack: value.stack,
+  }
+}

--- a/packages/extension-api/test/parts/HandleUncaughtExtensionError/HandleUncaughtExtensionError.test.ts
+++ b/packages/extension-api/test/parts/HandleUncaughtExtensionError/HandleUncaughtExtensionError.test.ts
@@ -1,0 +1,43 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { handleUncaughtExtensionError } from '../../../src/parts/HandleUncaughtExtensionError/HandleUncaughtExtensionError.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('forwards a serializable error to the extension management worker', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleUncaughtExtensionError'(error: unknown): Promise<void> {
+      invocations.push([error])
+    },
+  })
+  const error = new TypeError('x is not a function')
+  error.stack = 'TypeError: x is not a function\n    at activate (extension.js:2:3)'
+
+  await handleUncaughtExtensionError(error)
+
+  deepStrictEqual(invocations, [
+    [
+      {
+        code: undefined,
+        codeFrame: undefined,
+        constructor: {
+          name: 'TypeError',
+        },
+        message: 'x is not a function',
+        name: 'TypeError',
+        stack: 'TypeError: x is not a function\n    at activate (extension.js:2:3)',
+      },
+    ],
+  ])
+})

--- a/packages/extension-api/test/parts/HandleUnhandledError/HandleUnhandledError.test.ts
+++ b/packages/extension-api/test/parts/HandleUnhandledError/HandleUnhandledError.test.ts
@@ -1,0 +1,80 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { handleUnhandledError } from '../../../src/parts/HandleUnhandledError/HandleUnhandledError.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('prevents the worker error and forwards it', async () => {
+  const invocations: unknown[] = []
+  let prevented = false
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleUncaughtExtensionError'(error: unknown): Promise<void> {
+      invocations.push(error)
+    },
+  })
+  const error = new Error('extension failed')
+  const event = {
+    error,
+    preventDefault(): void {
+      prevented = true
+    },
+  } as ErrorEvent
+
+  await handleUnhandledError(event)
+
+  strictEqual(prevented, true)
+  deepStrictEqual(invocations, [
+    {
+      code: undefined,
+      codeFrame: undefined,
+      constructor: {
+        name: 'Error',
+      },
+      message: 'extension failed',
+      name: 'Error',
+      stack: error.stack,
+    },
+  ])
+})
+
+test('creates an error from event details when Chrome provides null', async () => {
+  const invocations: unknown[] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleUncaughtExtensionError'(error: unknown): Promise<void> {
+      invocations.push(error)
+    },
+  })
+  const event = {
+    colno: 7,
+    error: null,
+    filename: 'extension.js',
+    lineno: 4,
+    message: 'extension failed',
+    preventDefault(): void {},
+  } as ErrorEvent
+
+  await handleUnhandledError(event)
+
+  deepStrictEqual(invocations, [
+    {
+      code: undefined,
+      codeFrame: undefined,
+      constructor: {
+        name: 'Error',
+      },
+      message: 'extension failed',
+      name: undefined,
+      stack: 'extension failed\n    at extension.js:4:7',
+    },
+  ])
+})

--- a/packages/extension-api/test/parts/HandleUnhandledRejection/HandleUnhandledRejection.test.ts
+++ b/packages/extension-api/test/parts/HandleUnhandledRejection/HandleUnhandledRejection.test.ts
@@ -1,0 +1,36 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { handleUnhandledRejection } from '../../../src/parts/HandleUnhandledRejection/HandleUnhandledRejection.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('prevents the unhandled rejection and forwards its reason', async () => {
+  const invocations: unknown[] = []
+  let prevented = false
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.handleUncaughtExtensionError'(error: unknown): Promise<void> {
+      invocations.push(error)
+    },
+  })
+  const event = {
+    preventDefault(): void {
+      prevented = true
+    },
+    reason: 'extension rejected',
+  } as PromiseRejectionEvent
+
+  await handleUnhandledRejection(event)
+
+  strictEqual(prevented, true)
+  deepStrictEqual(invocations, ['extension rejected'])
+})


### PR DESCRIPTION
Suppresses Chrome's null worker error propagation and forwards uncaught isolated-extension errors and rejected promises to extension management with serializable stack details.