### PR TITLE
feature: add hidden electron web contents view api

### DIFF
--- a/packages/extension-api/README.md
+++ b/packages/extension-api/README.md
@@ -21,3 +21,13 @@ export const main = () => {
 ```
 
 The package is published as unbundled ESM with TypeScript declaration files, so extensions can bundle it with their own build tooling.
+
+Electron extensions can create an off-screen web contents view. It stays hidden for the lifetime of the handle, and disposing the handle destroys its web contents.
+
+```ts
+import { createElectronWebContentsView } from '@lvce-editor/api'
+
+const view = await createElectronWebContentsView({ url: 'https://example.com' })
+const title = await view.executeJavaScript<string>('document.title')
+await view.dispose()
+```

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,4 +1,5 @@
 export { activate } from './parts/Activation/Activation.ts'
+export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showQuickPick } from './parts/QuickPick/QuickPick.ts'
 export { getPreference, setPreference } from './parts/Preferences/Preferences.ts'
@@ -104,6 +105,11 @@ export type {
   RegisteredDiagnosticProvider,
 } from './parts/Diagnostic/Diagnostic.ts'
 export type { Disposable } from './parts/Disposable/Disposable.ts'
+export type {
+  CreateElectronWebContentsViewOptions,
+  ElectronWebContentsView,
+  ElectronWebContentsViewStats,
+} from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export type {
   FormattingEdit,
   FormattingProvider,

--- a/packages/extension-api/src/parts/ElectronWebContentsView/ElectronWebContentsView.ts
+++ b/packages/extension-api/src/parts/ElectronWebContentsView/ElectronWebContentsView.ts
@@ -1,0 +1,85 @@
+import { LazyTransferMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+export interface CreateElectronWebContentsViewOptions {
+  readonly url?: string
+}
+
+export interface ElectronWebContentsViewStats {
+  readonly canGoBack: boolean
+  readonly canGoForward: boolean
+  readonly title: string
+  readonly url: string
+}
+
+export interface ElectronWebContentsView {
+  readonly dispose: () => Promise<void>
+  readonly executeJavaScript: <T = unknown>(code: string) => Promise<T>
+  readonly getStats: () => Promise<ElectronWebContentsViewStats>
+  readonly loadUrl: (url: string) => Promise<void>
+  readonly reload: () => Promise<void>
+}
+
+const sendMessagePortToEmbedsProcess = async (port: MessagePort): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer(
+    'Extensions.sendMessagePortToElectron',
+    port,
+    'HandleMessagePortForEmbedsProcess.handleMessagePortForEmbedsProcess',
+  )
+}
+
+const disposeAfterCreateError = async (rpc: Rpc, id: number): Promise<void> => {
+  try {
+    await rpc.invoke('ElectronWebContentsView.disposeWebContentsView', id)
+  } finally {
+    await rpc.dispose()
+  }
+}
+
+export const createElectronWebContentsView = async ({ url }: CreateElectronWebContentsViewOptions = {}): Promise<ElectronWebContentsView> => {
+  const rpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: sendMessagePortToEmbedsProcess,
+  })
+  let id: number
+  try {
+    id = (await rpc.invoke('ElectronWebContentsView.createWebContentsView', 0, [])) as number
+  } catch (error) {
+    await rpc.dispose()
+    throw error
+  }
+  let disposed = false
+
+  const loadUrl = async (nextUrl: string): Promise<void> => {
+    await rpc.invoke('ElectronWebContentsView.setIframeSrc', id, nextUrl)
+  }
+
+  try {
+    if (url) {
+      await loadUrl(url)
+    }
+  } catch (error) {
+    await disposeAfterCreateError(rpc, id)
+    throw error
+  }
+
+  return {
+    async dispose(): Promise<void> {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      await disposeAfterCreateError(rpc, id)
+    },
+    async executeJavaScript<T = unknown>(code: string): Promise<T> {
+      return (await rpc.invoke('ElectronWebContentsView.insertJavaScript', id, code)) as T
+    },
+    async getStats(): Promise<ElectronWebContentsViewStats> {
+      return (await rpc.invoke('ElectronWebContentsView.getStats', id)) as ElectronWebContentsViewStats
+    },
+    loadUrl,
+    async reload(): Promise<void> {
+      await rpc.invoke('ElectronWebContentsView.reload', id)
+    },
+  }
+}

--- a/packages/extension-api/test/parts/ElectronWebContentsView/ElectronWebContentsView.test.ts
+++ b/packages/extension-api/test/parts/ElectronWebContentsView/ElectronWebContentsView.test.ts
@@ -1,0 +1,118 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, rejects, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createElectronWebContentsView } from '../../../src/parts/ElectronWebContentsView/ElectronWebContentsView.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+interface EmbedsMockOptions {
+  readonly failCreate?: boolean
+  readonly failLoad?: boolean
+  readonly invocations: unknown[][]
+}
+
+const registerEmbedsMock = ({ failCreate = false, failLoad = false, invocations }: EmbedsMockOptions): void => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.sendMessagePortToElectron'(port: MessagePort, initialCommand: string): Promise<void> {
+      invocations.push(['transfer', initialCommand])
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'ElectronWebContentsView.createWebContentsView'(restoreId: number, keyBindings: readonly string[]): number {
+            invocations.push(['create', restoreId, keyBindings])
+            if (failCreate) {
+              throw new Error('create failed')
+            }
+            return 42
+          },
+          'ElectronWebContentsView.disposeWebContentsView'(id: number): void {
+            invocations.push(['dispose', id])
+          },
+          'ElectronWebContentsView.getStats'(id: number): unknown {
+            invocations.push(['getStats', id])
+            return { canGoBack: false, canGoForward: true, title: 'Example', url: 'https://example.com/' }
+          },
+          'ElectronWebContentsView.insertJavaScript'(id: number, code: string): unknown {
+            invocations.push(['executeJavaScript', id, code])
+            return 'Example'
+          },
+          'ElectronWebContentsView.reload'(id: number): void {
+            invocations.push(['reload', id])
+          },
+          'ElectronWebContentsView.setIframeSrc'(id: number, url: string): void {
+            invocations.push(['loadUrl', id, url])
+            if (failLoad) {
+              throw new Error('load failed')
+            }
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+}
+
+test('creates a hidden web contents view and forwards operations', async () => {
+  const invocations: unknown[][] = []
+  registerEmbedsMock({ invocations })
+
+  const view = await createElectronWebContentsView({
+    url: 'https://example.com',
+  })
+
+  strictEqual(await view.executeJavaScript<string>('document.title'), 'Example')
+  deepStrictEqual(await view.getStats(), {
+    canGoBack: false,
+    canGoForward: true,
+    title: 'Example',
+    url: 'https://example.com/',
+  })
+  await view.reload()
+  await view.loadUrl('https://example.com/next')
+  await view.dispose()
+  await view.dispose()
+
+  deepStrictEqual(invocations, [
+    ['transfer', 'HandleMessagePortForEmbedsProcess.handleMessagePortForEmbedsProcess'],
+    ['create', 0, []],
+    ['loadUrl', 42, 'https://example.com'],
+    ['executeJavaScript', 42, 'document.title'],
+    ['getStats', 42],
+    ['reload', 42],
+    ['loadUrl', 42, 'https://example.com/next'],
+    ['dispose', 42],
+  ])
+})
+
+test('disposes the view and rpc when initial navigation fails', async () => {
+  const invocations: unknown[][] = []
+  registerEmbedsMock({ failLoad: true, invocations })
+
+  await rejects(createElectronWebContentsView({ url: 'https://example.com' }), /load failed/)
+  deepStrictEqual(invocations, [
+    ['transfer', 'HandleMessagePortForEmbedsProcess.handleMessagePortForEmbedsProcess'],
+    ['create', 0, []],
+    ['loadUrl', 42, 'https://example.com'],
+    ['dispose', 42],
+  ])
+})
+
+test('disposes the rpc when view creation fails', async () => {
+  const invocations: unknown[][] = []
+  registerEmbedsMock({ failCreate: true, invocations })
+
+  await rejects(createElectronWebContentsView(), /create failed/)
+  deepStrictEqual(invocations, [
+    ['transfer', 'HandleMessagePortForEmbedsProcess.handleMessagePortForEmbedsProcess'],
+    ['create', 0, []],
+  ])
+})


### PR DESCRIPTION
Adds a typed extension API for creating and controlling hidden Electron WebContentsViews through the existing embeds-process bridge. Includes navigation, JavaScript execution, page statistics, reload and deterministic disposal, with API documentation and failure-path tests.