### PR TITLE
Add access token extension API

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,4 +1,5 @@
 export { activate } from './parts/Activation/Activation.ts'
+export { getAccessToken } from './parts/Authentication/Authentication.ts'
 export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showQuickPick } from './parts/QuickPick/QuickPick.ts'

--- a/packages/extension-api/src/parts/Authentication/Authentication.ts
+++ b/packages/extension-api/src/parts/Authentication/Authentication.ts
@@ -1,0 +1,5 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+export const getAccessToken = (): Promise<string> => {
+  return ExtensionManagementWorker.invoke('Extensions.getAccessToken')
+}

--- a/packages/extension-api/test/parts/Authentication/Authentication.test.ts
+++ b/packages/extension-api/test/parts/Authentication/Authentication.test.ts
@@ -1,0 +1,25 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { getAccessToken } from '../../../src/parts/Authentication/Authentication.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('getAccessToken invokes extension management worker', async () => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.getAccessToken'(): Promise<string> {
+      return 'token-1'
+    },
+  })
+
+  strictEqual(await getAccessToken(), 'token-1')
+})


### PR DESCRIPTION
Expose a tree-shakeable getAccessToken API that requests the token through extension management.