### PR TITLE
feature: add language server extension API

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -27,6 +27,7 @@ export {
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
 export { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
+export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'
 export {
   registerBraceCompletionProvider,
   registerClosingTagProvider,
@@ -120,6 +121,7 @@ export type {
 export type { FileSystemDirent } from './parts/FileSystem/FileSystem.ts'
 export type { HandleExtensionManagementMessagePortOptions } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 export type { HoverProvider, HoverProviderRegistrySnapshot, HoverResult, RegisteredHoverProvider } from './parts/Hover/Hover.ts'
+export type { LanguageServerOptions, LanguageServerRegistrySnapshot } from './parts/LanguageServer/LanguageServer.ts'
 export type { OutputChannel } from './parts/OutputChannelHandle/OutputChannelHandle.ts'
 export type { OutputChannelRegistrySnapshot } from './parts/OutputChannelRegistrySnapshot/OutputChannelRegistrySnapshot.ts'
 export type { RegisteredOutputChannel } from './parts/RegisteredOutputChannel/RegisteredOutputChannel.ts'

--- a/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
+++ b/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
@@ -5,6 +5,7 @@ import { executeFormattingProvider, getFormattingProviderRegistrySnapshot } from
 import { getStatusBarItems } from '../GetStatusBarItems/GetStatusBarItems.ts'
 import { executeHoverProvider, getHoverProviderRegistrySnapshot } from '../Hover/Hover.ts'
 import { executeLanguageProvider, executeOrganizeImportsProvider } from '../LanguageProvider/LanguageProvider.ts'
+import { getLanguageServerRegistrySnapshot } from '../LanguageServer/LanguageServer.ts'
 import { getOutputChannelRegistrySnapshot } from '../OutputChannel/OutputChannel.ts'
 import {
   executeSourceControlAcceptInput,
@@ -61,6 +62,7 @@ export const commandMap = {
   'ExtensionApi.getDiagnosticProviderRegistrySnapshot': getDiagnosticProviderRegistrySnapshot,
   'ExtensionApi.getFormattingProviderRegistrySnapshot': getFormattingProviderRegistrySnapshot,
   'ExtensionApi.getHoverProviderRegistrySnapshot': getHoverProviderRegistrySnapshot,
+  'ExtensionApi.getLanguageServerRegistrySnapshot': getLanguageServerRegistrySnapshot,
   'ExtensionApi.getOutputChannelRegistrySnapshot': getOutputChannelRegistrySnapshot,
   'ExtensionApi.getSourceControlProviderRegistrySnapshot': getSourceControlProviderRegistrySnapshot,
   'ExtensionApi.getStatusBarItems': getStatusBarItems,

--- a/packages/extension-api/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/extension-api/src/parts/LanguageServer/LanguageServer.ts
@@ -1,0 +1,5 @@
+export { getLanguageServerRegistrySnapshot } from '../LanguageServerRegistry/LanguageServerRegistry.ts'
+export { registerLanguageServer } from '../LanguageServerRegistry/LanguageServerRegistry.ts'
+export { resetLanguageServerRegistry } from '../LanguageServerRegistry/LanguageServerRegistry.ts'
+export type { LanguageServerOptions } from '../LanguageServerOptions/LanguageServerOptions.ts'
+export type { LanguageServerRegistrySnapshot } from '../LanguageServerRegistrySnapshot/LanguageServerRegistrySnapshot.ts'

--- a/packages/extension-api/src/parts/LanguageServerOptions/LanguageServerOptions.ts
+++ b/packages/extension-api/src/parts/LanguageServerOptions/LanguageServerOptions.ts
@@ -1,0 +1,6 @@
+export interface LanguageServerOptions {
+  readonly argv: readonly string[]
+  readonly id: string
+  readonly languageId: string
+  readonly uri: string
+}

--- a/packages/extension-api/src/parts/LanguageServerRegistry/LanguageServerRegistry.ts
+++ b/packages/extension-api/src/parts/LanguageServerRegistry/LanguageServerRegistry.ts
@@ -1,0 +1,54 @@
+import type { Disposable } from '../Disposable/Disposable.ts'
+import type { LanguageServerOptions } from '../LanguageServerOptions/LanguageServerOptions.ts'
+import type { LanguageServerRegistrySnapshot } from '../LanguageServerRegistrySnapshot/LanguageServerRegistrySnapshot.ts'
+import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
+
+const languageServers: Record<string, LanguageServerOptions> = Object.create(null)
+
+const assertNonEmptyString: (value: unknown, name: string) => asserts value is string = (value, name) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ExtensionApiError(`language server is missing ${name}`)
+  }
+}
+
+const validateLanguageServer = (options: LanguageServerOptions): void => {
+  if (!options) {
+    throw new ExtensionApiError('language server is not defined')
+  }
+  assertNonEmptyString(options.id, 'id')
+  assertNonEmptyString(options.languageId, 'languageId')
+  assertNonEmptyString(options.uri, 'uri')
+  if (!Array.isArray(options.argv) || options.argv.some((argument) => typeof argument !== 'string')) {
+    throw new ExtensionApiError(`language server ${options.id} has invalid argv`)
+  }
+  if (options.id in languageServers) {
+    throw new ExtensionApiError(`language server ${options.id} is already registered`)
+  }
+}
+
+export const registerLanguageServer = (options: LanguageServerOptions): Disposable => {
+  validateLanguageServer(options)
+  languageServers[options.id] = {
+    argv: [...options.argv],
+    id: options.id,
+    languageId: options.languageId,
+    uri: options.uri,
+  }
+  return {
+    dispose(): void {
+      delete languageServers[options.id]
+    },
+  }
+}
+
+export const getLanguageServerRegistrySnapshot = (): LanguageServerRegistrySnapshot => {
+  return {
+    languageServers: Object.values(languageServers),
+  }
+}
+
+export const resetLanguageServerRegistry = (): void => {
+  for (const id of Object.keys(languageServers)) {
+    delete languageServers[id]
+  }
+}

--- a/packages/extension-api/src/parts/LanguageServerRegistrySnapshot/LanguageServerRegistrySnapshot.ts
+++ b/packages/extension-api/src/parts/LanguageServerRegistrySnapshot/LanguageServerRegistrySnapshot.ts
@@ -1,0 +1,5 @@
+import type { LanguageServerOptions } from '../LanguageServerOptions/LanguageServerOptions.ts'
+
+export interface LanguageServerRegistrySnapshot {
+  readonly languageServers: readonly LanguageServerOptions[]
+}

--- a/packages/extension-api/test/parts/LanguageServerRegistry/LanguageServerRegistry.test.ts
+++ b/packages/extension-api/test/parts/LanguageServerRegistry/LanguageServerRegistry.test.ts
@@ -1,0 +1,52 @@
+import { deepStrictEqual, throws } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import {
+  getLanguageServerRegistrySnapshot,
+  registerLanguageServer,
+  resetLanguageServerRegistry,
+} from '../../../src/parts/LanguageServerRegistry/LanguageServerRegistry.ts'
+
+afterEach(() => {
+  resetLanguageServerRegistry()
+})
+
+test('registerLanguageServer exposes serializable process metadata', () => {
+  registerLanguageServer({
+    argv: ['--lsp', '--stdio'],
+    id: 'typescript-native',
+    languageId: 'typescript',
+    uri: '../../node_modules/typescript/bin/tsc',
+  })
+
+  deepStrictEqual(getLanguageServerRegistrySnapshot(), {
+    languageServers: [
+      {
+        argv: ['--lsp', '--stdio'],
+        id: 'typescript-native',
+        languageId: 'typescript',
+        uri: '../../node_modules/typescript/bin/tsc',
+      },
+    ],
+  })
+})
+
+test('registerLanguageServer returns a disposable registration', () => {
+  const disposable = registerLanguageServer({ argv: [], id: 'sample', languageId: 'xyz', uri: 'server' })
+  disposable.dispose()
+  deepStrictEqual(getLanguageServerRegistrySnapshot(), { languageServers: [] })
+})
+
+test('registerLanguageServer rejects invalid registrations', () => {
+  throws(() => registerLanguageServer(undefined as never), /language server is not defined/)
+  throws(() => registerLanguageServer({ argv: [], id: '', languageId: 'xyz', uri: 'server' }), /language server is missing id/)
+  throws(
+    () => registerLanguageServer({ argv: [1] as never, id: 'sample', languageId: 'xyz', uri: 'server' }),
+    /language server sample has invalid argv/,
+  )
+})
+
+test('registerLanguageServer rejects duplicate ids', () => {
+  const options = { argv: [], id: 'sample', languageId: 'xyz', uri: 'server' }
+  registerLanguageServer(options)
+  throws(() => registerLanguageServer(options), /language server sample is already registered/)
+})


### PR DESCRIPTION
Adds isolated-extension registration for serializable language server executable metadata.

Exposes registered language servers to extension management over RPC.