### PR TITLE
fix: support tracked pointer events in view api

### DIFF
--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -45,6 +45,7 @@ export interface DomEventListener {
   readonly passive?: boolean
   readonly preventDefault?: boolean
   readonly stopPropagation?: boolean
+  readonly trackPointerEvents?: readonly (string | number)[]
 }
 
 export interface VirtualDomViewInstance {

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -64,6 +64,13 @@ const assertEventListener: (viewId: string, listener: unknown, index: number) =>
   assertBoolean(eventListener.passive, `view ${viewId} event listener ${index} has invalid passive`)
   assertBoolean(eventListener.preventDefault, `view ${viewId} event listener ${index} has invalid preventDefault`)
   assertBoolean(eventListener.stopPropagation, `view ${viewId} event listener ${index} has invalid stopPropagation`)
+  if (
+    eventListener.trackPointerEvents !== undefined &&
+    (!Array.isArray(eventListener.trackPointerEvents) ||
+      eventListener.trackPointerEvents.some((event) => typeof event !== 'string' && typeof event !== 'number'))
+  ) {
+    throw new ExtensionApiError(`view ${viewId} event listener ${index} has invalid trackPointerEvents`)
+  }
 }
 
 const assertEventListeners = (view: View<any>): void => {

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -220,6 +220,7 @@ test('registerView includes event listeners in registry snapshot', () => {
       name: 'handleDrop',
       params: ['handleViewEvent', 'drop', 'event.target.name'],
       preventDefault: true,
+      trackPointerEvents: ['handlePointerMove', 'handlePointerUp'],
     },
   ]
   registerView({
@@ -265,6 +266,23 @@ test('registerView rejects invalid event listeners', () => {
       kind: 'virtualDom',
     } as any)
   }, /view sample\.views\.testing event listener 0 has invalid preventDefault/)
+})
+
+test('registerView rejects invalid tracked pointer events', () => {
+  throws(() => {
+    registerView({
+      create() {},
+      eventListeners: [
+        {
+          name: 'handlePointerDown',
+          params: ['handlePointerDown'],
+          trackPointerEvents: ['handlePointerMove', true],
+        },
+      ],
+      id: 'sample.views.testing',
+      kind: 'virtualDom',
+    } as any)
+  }, /view sample\.views\.testing event listener 0 has invalid trackPointerEvents/)
 })
 
 test('createViewInstance renders initial virtual dom', async () => {


### PR DESCRIPTION
Allow extension view event listeners to declare tracked pointer-move and pointer-up handlers through the public API, with registry validation and regression coverage.