### PR TITLE
Bridge isolated source control providers

### DIFF
--- a/packages/extension-host-worker/src/parts/ExecuteIsolatedSourceControlProvider/ExecuteIsolatedSourceControlProvider.ts
+++ b/packages/extension-host-worker/src/parts/ExecuteIsolatedSourceControlProvider/ExecuteIsolatedSourceControlProvider.ts
@@ -1,0 +1,35 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+interface SourceControlProviderResult {
+  readonly found: boolean
+  readonly result?: unknown
+}
+
+const isUnavailableError = (error: unknown): boolean => {
+  return (
+    (error instanceof Error && error.name === 'CommandNotFoundError') ||
+    (error instanceof TypeError && error.message === "Cannot read properties of undefined (reading 'invoke')")
+  )
+}
+
+export const getEnabledProviderIds = async (scheme: string, root: string): Promise<readonly string[]> => {
+  try {
+    return await ExtensionManagementWorker.invoke('Extensions.getEnabledSourceControlProviderIds', scheme, root)
+  } catch (error) {
+    if (isUnavailableError(error)) {
+      return []
+    }
+    throw error
+  }
+}
+
+export const execute = async (providerId: string, methodName: string, ...args: readonly unknown[]): Promise<SourceControlProviderResult> => {
+  try {
+    return await ExtensionManagementWorker.invoke('Extensions.executeSourceControlProvider', providerId, methodName, ...args)
+  } catch (error) {
+    if (isUnavailableError(error)) {
+      return { found: false }
+    }
+    throw error
+  }
+}

--- a/packages/extension-host-worker/src/parts/ExtensionHostSourceControl/ExtensionHostSourceControl.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostSourceControl/ExtensionHostSourceControl.ts
@@ -1,5 +1,6 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as Assert from '../Assert/Assert.ts'
+import * as ExecuteIsolatedSourceControlProvider from '../ExecuteIsolatedSourceControlProvider/ExecuteIsolatedSourceControlProvider.ts'
 import { getRemoteUrlSync } from '../ExtensionHostUrl/ExtensionHostUrl.ts'
 import { getExtensions } from '../GetExtensions/GetExtensions.ts'
 
@@ -28,26 +29,45 @@ const getFilesFromProvider = (provider) => {
 }
 
 export const getChangedFiles = async (providerId) => {
-  const provider = getProvider(providerId)
-  const changedFiles = await getFilesFromProvider(provider)
-  const flattenedChangedFiles = changedFiles
-  return flattenedChangedFiles
+  const provider = state.providers[providerId]
+  if (provider) {
+    return getFilesFromProvider(provider)
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetChangedFiles')
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getFilesFromProvider(getProvider(providerId))
 }
 
 export const getBadgeCount = async (providerId) => {
-  const provider = getProvider(providerId)
-  if (typeof provider.getBadgeCount === 'function') {
-    return provider.getBadgeCount()
+  const provider = state.providers[providerId]
+  if (provider) {
+    if (typeof provider.getBadgeCount === 'function') {
+      return provider.getBadgeCount()
+    }
+    const changedFiles = await getFilesFromProvider(provider)
+    return changedFiles.length
   }
-  const changedFiles = await getFilesFromProvider(provider)
-  return changedFiles.length
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetBadgeCount')
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getFilesFromProvider(getProvider(providerId))
 }
 
 export const getFileBefore = async (providerId, uri) => {
   Assert.string(providerId)
   Assert.string(uri)
-  const provider = getProvider(providerId)
-  return provider.getFileBefore(uri)
+  const provider = state.providers[providerId]
+  if (provider) {
+    return provider.getFileBefore(uri)
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetFileBefore', uri)
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getProvider(providerId).getFileBefore(uri)
 }
 
 const getGroupsFromProvider = async (provider, cwd) => {
@@ -69,56 +89,105 @@ const getGroupsFromProvider = async (provider, cwd) => {
 }
 
 export const getGroups = async (providerId, cwd) => {
-  const provider = getProvider(providerId)
-  const groups = await getGroupsFromProvider(provider, cwd)
-  return groups
+  const provider = state.providers[providerId]
+  if (provider) {
+    return getGroupsFromProvider(provider, cwd)
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetGroups', cwd)
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getGroupsFromProvider(getProvider(providerId), cwd)
 }
 
 export const acceptInput = async (providerId, value) => {
-  const provider = getProvider(providerId)
-  await provider.acceptInput(value)
+  const provider = state.providers[providerId]
+  if (provider) {
+    await provider.acceptInput(value)
+    return
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlAcceptInput', value)
+  if (!isolated.found) {
+    getProvider(providerId)
+  }
 }
 
 export const generateCommitMessage = async (providerId) => {
-  const provider = getProvider(providerId)
-  if (typeof provider.generateCommitMessage !== 'function') {
-    throw new TypeError('source control provider is missing required function generateCommitMessage')
+  const provider = state.providers[providerId]
+  if (provider) {
+    if (typeof provider.generateCommitMessage !== 'function') {
+      throw new TypeError('source control provider is missing required function generateCommitMessage')
+    }
+    return provider.generateCommitMessage()
   }
-  return provider.generateCommitMessage()
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGenerateCommitMessage')
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getProvider(providerId)
 }
 
 export const getFeatures = async (providerId) => {
-  const provider = getProvider(providerId)
-  if (typeof provider.getFeatures === 'function') {
-    return provider.getFeatures()
-  }
-  if (provider.features && typeof provider.features === 'object') {
-    return provider.features
-  }
-  if ('showGenerateCommitMessageButton' in provider) {
-    return {
-      showGenerateCommitMessageButton: provider.showGenerateCommitMessageButton,
+  const provider = state.providers[providerId]
+  if (provider) {
+    if (typeof provider.getFeatures === 'function') {
+      return provider.getFeatures()
     }
+    if (provider.features && typeof provider.features === 'object') {
+      return provider.features
+    }
+    if ('showGenerateCommitMessageButton' in provider) {
+      return {
+        showGenerateCommitMessageButton: provider.showGenerateCommitMessageButton,
+      }
+    }
+    return {}
   }
-  return {}
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetFeatures')
+  if (isolated.found) {
+    return isolated.result
+  }
+  return getProvider(providerId)
 }
 
-export const add = async (path) => {
-  const provider = Object.values(state.providers)[0]
-  if (!provider) {
+export const add = async (providerId, path?) => {
+  if (path === undefined) {
+    const provider = Object.values(state.providers)[0]
+    if (provider) {
+      // @ts-ignore
+      await provider.add(providerId)
+    }
     return
   }
-  // @ts-ignore
-  await provider.add(path)
+  const provider = state.providers[providerId]
+  if (provider) {
+    await provider.add(path)
+    return
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlAdd', path)
+  if (!isolated.found) {
+    getProvider(providerId)
+  }
 }
 
-export const discard = async (path) => {
-  const provider = Object.values(state.providers)[0]
-  if (!provider) {
+export const discard = async (providerId, path?) => {
+  if (path === undefined) {
+    const provider = Object.values(state.providers)[0]
+    if (provider) {
+      // @ts-ignore
+      await provider.discard(providerId)
+    }
     return
   }
-  // @ts-ignore
-  await provider.discard(path)
+  const provider = state.providers[providerId]
+  if (provider) {
+    await provider.discard(path)
+    return
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlDiscard', path)
+  if (!isolated.found) {
+    getProvider(providerId)
+  }
 }
 
 export const getEnabledProviderIds = async (scheme, root) => {
@@ -138,7 +207,8 @@ export const getEnabledProviderIds = async (scheme, root) => {
       enabledIds.push(provider.id)
     }
   }
-  return enabledIds
+  const isolatedIds = await ExecuteIsolatedSourceControlProvider.getEnabledProviderIds(scheme, root)
+  return [...new Set([...enabledIds, ...isolatedIds])]
 }
 
 export const reset = () => {
@@ -166,11 +236,10 @@ export const getIconDefinitions = async (providerId): Promise<readonly string[]>
 
 export const getFileDecorations = async (providerId: any, uris: readonly string[]): Promise<readonly any[]> => {
   const provider = state.providers[providerId]
-  // @ts-ignore
-  if (!provider || !provider.getFileDecorations) {
-    return []
+  if (provider) {
+    // @ts-ignore
+    return provider.getFileDecorations ? provider.getFileDecorations(uris) : []
   }
-  // @ts-ignore
-  const decorations = await provider.getFileDecorations(uris)
-  return decorations
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetFileDecorations', uris)
+  return isolated.found ? (isolated.result as readonly any[]) : []
 }

--- a/packages/extension-host-worker/test/ExtensionHostSourceControl.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostSourceControl.test.ts
@@ -1,8 +1,19 @@
-import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { DisposableMockRpc } from '@lvce-editor/rpc-registry'
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionHostSourceControl from '../src/parts/ExtensionHostSourceControl/ExtensionHostSourceControl.ts'
+
+const state: { extensionManagementWorker: DisposableMockRpc | undefined } = {
+  extensionManagementWorker: undefined,
+}
 
 beforeEach(() => {
   ExtensionHostSourceControl.reset()
+})
+
+afterEach(() => {
+  state.extensionManagementWorker?.[Symbol.dispose]()
+  state.extensionManagementWorker = undefined
 })
 
 test('getChangedFiles', async () => {
@@ -80,6 +91,63 @@ test('getEnabledProviderIds', async () => {
   expect(provider2.isActive).toHaveBeenCalledTimes(1)
   // @ts-ignore
   expect(provider2.isActive).toHaveBeenCalledWith('', '/test/folder')
+})
+
+test('getEnabledProviderIds - includes isolated providers', async () => {
+  state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getEnabledSourceControlProviderIds': async () => ['git'],
+  })
+
+  await expect(ExtensionHostSourceControl.getEnabledProviderIds('file', '/workspace')).resolves.toEqual(['git'])
+})
+
+test('getChangedFiles - isolated provider', async () => {
+  const invocations: unknown[] = []
+  state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeSourceControlProvider': async (...args: readonly unknown[]) => {
+      invocations.push(args)
+      return { found: true, result: [{ file: '/workspace/file.txt', status: 1 }] }
+    },
+  })
+
+  await expect(ExtensionHostSourceControl.getChangedFiles('git')).resolves.toEqual([{ file: '/workspace/file.txt', status: 1 }])
+  expect(invocations).toEqual([['git', 'executeSourceControlGetChangedFiles']])
+})
+
+test('getGroups - isolated provider', async () => {
+  const invocations: unknown[] = []
+  state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeSourceControlProvider': async (...args: readonly unknown[]) => {
+      invocations.push(args)
+      return { found: true, result: [{ id: 'changes', items: [], label: 'Changes' }] }
+    },
+  })
+
+  await expect(ExtensionHostSourceControl.getGroups('git', '/workspace')).resolves.toEqual([{ id: 'changes', items: [], label: 'Changes' }])
+  expect(invocations).toEqual([['git', 'executeSourceControlGetGroups', '/workspace']])
+})
+
+test('add - preserves legacy single-path calls', async () => {
+  const add = jest.fn()
+  ExtensionHostSourceControl.registerSourceControlProvider({ add, id: 'git' })
+
+  await ExtensionHostSourceControl.add('/workspace/file.txt')
+
+  expect(add).toHaveBeenCalledWith('/workspace/file.txt')
+})
+
+test('add - isolated provider', async () => {
+  const invocations: unknown[] = []
+  state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeSourceControlProvider': async (...args: readonly unknown[]) => {
+      invocations.push(args)
+      return { found: true }
+    },
+  })
+
+  await ExtensionHostSourceControl.add('git', '/workspace/file.txt')
+
+  expect(invocations).toEqual([['git', 'executeSourceControlAdd', '/workspace/file.txt']])
 })
 
 test('generateCommitMessage', async () => {


### PR DESCRIPTION
Summary:\n- fall back from legacy providers to isolated source control providers\n- preserve legacy behavior while forwarding provider operations