### PR TITLE
feature: expose workspace uri

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -25,7 +25,7 @@ export {
   resetFormattingProviderRegistry,
 } from './parts/Formatting/Formatting.ts'
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
-export { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
+export { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'
 export {

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -8,6 +8,10 @@ export const getWorkspaceFolder = async (): Promise<string> => {
   return (await executeCommand('Workspace.getPath')) as string
 }
 
+export const getWorkspaceUri = async (): Promise<string> => {
+  return (await executeCommand('Workspace.getUri')) as string
+}
+
 export const handleWorkspaceRefresh = async (): Promise<void> => {
   await executeCommand('Layout.handleWorkspaceRefresh')
 }

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { confirm, getWorkspaceFolder, handleWorkspaceRefresh, openUri } from '../../../src/parts/Host/Host.ts'
+import { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from '../../../src/parts/Host/Host.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -22,6 +22,9 @@ test('host helpers execute renderer commands through extension management', asyn
       if (id === 'Workspace.getPath') {
         return '/workspace'
       }
+      if (id === 'Workspace.getUri') {
+        return 'file:///workspace'
+      }
       if (id === 'ConfirmPrompt.prompt') {
         return true
       }
@@ -30,12 +33,14 @@ test('host helpers execute renderer commands through extension management', asyn
   })
 
   strictEqual(await getWorkspaceFolder(), '/workspace')
+  strictEqual(await getWorkspaceUri(), 'file:///workspace')
   strictEqual(await confirm('Discard changes?'), true)
   await handleWorkspaceRefresh()
   await openUri('/workspace/file.txt')
 
   deepStrictEqual(invocations, [
     ['Workspace.getPath'],
+    ['Workspace.getUri'],
     ['ConfirmPrompt.prompt', 'Discard changes?'],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', '/workspace/file.txt'],


### PR DESCRIPTION
Expose the currently open workspace URI through the public extension API so extensions can use cross-platform file URIs instead of filesystem paths.