### PR TITLE
feature: support extension view scroll positions

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -86,6 +86,7 @@ export type {
   MenuEntry,
   ViewRegistrySnapshot,
   ViewRenderResult,
+  ViewScrollPosition,
   ViewSelection,
   VirtualDomViewInstance,
 } from './parts/View/View.ts'

--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -38,6 +38,8 @@ export interface ViewSelection {
   readonly start: number
 }
 
+export type ViewScrollPosition = readonly [selector: string, scrollTop: number]
+
 export interface DomEventListener {
   readonly capture?: boolean
   readonly name: string | number
@@ -56,6 +58,7 @@ export interface VirtualDomViewInstance {
   readonly render: () => readonly VirtualDomNode[] | Promise<readonly VirtualDomNode[]>
   readonly renderActions?: () => readonly ViewAction[] | Promise<readonly ViewAction[]>
   readonly renderFocus?: (oldContext: Readonly<Record<string, boolean>>, newContext: Readonly<Record<string, boolean>>) => string | Promise<string>
+  readonly renderScrollPosition?: () => readonly [] | ViewScrollPosition | Promise<readonly [] | ViewScrollPosition>
   readonly renderSelections?: () => readonly ViewSelection[] | Promise<readonly ViewSelection[]>
   readonly renderTitle?: () => string | Promise<string>
   readonly saveState?: () => unknown
@@ -95,6 +98,7 @@ export interface ViewRegistrySnapshot {
 export interface ViewRenderResultDom {
   readonly dom: readonly VirtualDomNode[]
   readonly focusSelector?: string
+  readonly scrollPosition?: ViewScrollPosition
   readonly selections?: readonly ViewSelection[]
   readonly title?: string
   readonly type: 'setDom'
@@ -103,6 +107,7 @@ export interface ViewRenderResultDom {
 export interface ViewRenderResultPatches {
   readonly focusSelector?: string
   readonly patches: readonly unknown[]
+  readonly scrollPosition?: ViewScrollPosition
   readonly selections?: readonly ViewSelection[]
   readonly title?: string
   readonly type: 'setPatches'

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -11,6 +11,7 @@ import type {
   ViewEvent,
   ViewRegistrySnapshot,
   ViewRenderResult,
+  ViewScrollPosition,
   ViewSelection,
   VirtualDomViewInstance,
 } from '../View/View.ts'
@@ -309,6 +310,21 @@ const normalizeViewSelections = (selections: unknown): readonly ViewSelection[] 
   return selections.map(normalizeViewSelection)
 }
 
+const normalizeViewScrollPosition = (scrollPosition: unknown): readonly [] | ViewScrollPosition => {
+  if (!Array.isArray(scrollPosition)) {
+    throw new ExtensionApiError('view scroll position must be an array')
+  }
+  if (scrollPosition.length === 0) {
+    return []
+  }
+  if (scrollPosition.length !== 2) {
+    throw new ExtensionApiError('view scroll position must contain a selector and scroll top')
+  }
+  assertString(scrollPosition[0], 'view scroll position is missing selector')
+  assertNumber(scrollPosition[1], 'view scroll position is missing scroll top')
+  return [scrollPosition[0], scrollPosition[1]]
+}
+
 const renderPatches = async (uid: number, instance: VirtualDomViewInstance): Promise<ViewRenderResult> => {
   const oldDom = renderedDoms[uid] || []
   const newDom = await renderDom(instance)
@@ -433,6 +449,20 @@ const withSelections = async (result: ViewRenderResult, instance: VirtualDomView
   }
 }
 
+const withScrollPosition = async (result: ViewRenderResult, instance: VirtualDomViewInstance): Promise<ViewRenderResult> => {
+  if (typeof instance.renderScrollPosition !== 'function') {
+    return result
+  }
+  const scrollPosition = normalizeViewScrollPosition(await instance.renderScrollPosition())
+  if (scrollPosition.length === 0) {
+    return result
+  }
+  return {
+    ...result,
+    scrollPosition,
+  }
+}
+
 const withRenderMetadata = async (
   result: ViewRenderResult,
   instance: VirtualDomViewInstance,
@@ -440,7 +470,8 @@ const withRenderMetadata = async (
 ): Promise<ViewRenderResult> => {
   const resultWithFocus = await withFocusSelector(result, instance, contextChange)
   const resultWithSelections = await withSelections(resultWithFocus, instance)
-  return withTitle(resultWithSelections, instance)
+  const resultWithScrollPosition = await withScrollPosition(resultWithSelections, instance)
+  return withTitle(resultWithScrollPosition, instance)
 }
 
 const maybeClearContext = async (uid: number, viewId: string): Promise<void> => {

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -857,6 +857,84 @@ test('renderSelections rejects invalid results', async () => {
   await rejects(createViewInstance('sample.views.testing', 1), /view selection 0 is missing name/)
 })
 
+test('renderScrollPosition is included after every view render', async () => {
+  let scrollTop = 100
+  registerView({
+    create() {
+      return {
+        handleEvent() {
+          scrollTop = 200
+        },
+        render() {
+          return []
+        },
+        renderScrollPosition() {
+          return ['.Messages', scrollTop] as const
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  deepStrictEqual(await createViewInstance('sample.views.testing', 1), {
+    dom: [],
+    scrollPosition: ['.Messages', 100],
+    type: 'setDom',
+  })
+  deepStrictEqual(await dispatchViewEvent(1, { type: 'click' }), {
+    patches: [],
+    scrollPosition: ['.Messages', 200],
+    type: 'setPatches',
+  })
+  deepStrictEqual(await renderViewInstance(1), {
+    patches: [],
+    scrollPosition: ['.Messages', 200],
+    type: 'setPatches',
+  })
+})
+
+test('renderScrollPosition empty result is omitted', async () => {
+  registerView({
+    create() {
+      return {
+        render() {
+          return []
+        },
+        renderScrollPosition() {
+          return [] as const
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  deepStrictEqual(await createViewInstance('sample.views.testing', 1), {
+    dom: [],
+    type: 'setDom',
+  })
+})
+
+test('renderScrollPosition rejects invalid results', async () => {
+  registerView({
+    create() {
+      return {
+        render() {
+          return []
+        },
+        renderScrollPosition() {
+          return ['.Messages'] as any
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await rejects(createViewInstance('sample.views.testing', 1), /view scroll position must contain a selector and scroll top/)
+})
+
 test('saveViewInstanceState returns instance state', async () => {
   registerView({
     create() {


### PR DESCRIPTION
Adds optional renderScrollPosition metadata for virtual DOM extension views so extensions can request a scoped scrollTop update after each render.