### PR TITLE
feature: support manifest node rpc entries

### DIFF
--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -8,8 +8,9 @@ export interface CreateRpcOptions {
 }
 
 export interface CreateNodeRpcOptions {
+  readonly id?: string
   readonly name?: string
-  readonly path: string
+  readonly path?: string
 }
 
 const sendMessagePortToWebWorker = async (port: MessagePort, name: string, url: string): Promise<void> => {
@@ -32,14 +33,30 @@ export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOp
   return createMessagePortRpc(commandMap, (port) => sendMessagePortToWebWorker(port, name, url))
 }
 
-export const createNodeRpc = async ({ name = '', path }: CreateNodeRpcOptions): Promise<Rpc> => {
-  const id = await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.create', name, path)
+interface ResolvedNodeRpcOptions {
+  readonly name: string
+  readonly path: string
+}
+
+const resolveNodeRpcOptions = async ({ id, name = '', path }: CreateNodeRpcOptions): Promise<ResolvedNodeRpcOptions> => {
+  if (id) {
+    return ExtensionManagementWorker.invoke('Extensions.getNodeRpcInfo', id) as Promise<ResolvedNodeRpcOptions>
+  }
+  if (path) {
+    return { name, path }
+  }
+  throw new TypeError('createNodeRpc requires an id or path')
+}
+
+export const createNodeRpc = async (options: CreateNodeRpcOptions): Promise<Rpc> => {
+  const { name, path } = await resolveNodeRpcOptions(options)
+  const rpcId = await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.create', name, path)
   const invoke = (method: string, ...params: readonly any[]): Promise<any> => {
-    return ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.invoke', id, method, ...params)
+    return ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.invoke', rpcId, method, ...params)
   }
   return {
     async dispose(): Promise<void> {
-      await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.dispose', id)
+      await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.dispose', rpcId)
     },
     invoke,
     invokeAndTransfer: invoke,

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -1,6 +1,6 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
-import { deepStrictEqual, strictEqual } from 'node:assert/strict'
+import { deepStrictEqual, rejects, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { createNodeRpc, createRpc } from '../../../src/parts/Rpc/Rpc.ts'
 
@@ -42,6 +42,41 @@ test('createNodeRpc proxies calls through the renderer worker', async () => {
     ['ExtensionNodeRpc.invoke', 42, 'Git.status'],
     ['ExtensionNodeRpc.dispose', 42],
   ])
+})
+
+test('createNodeRpc resolves a declared rpc entry', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...params: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...params])
+      if (id === 'ExtensionNodeRpc.create') {
+        return 42
+      }
+      return undefined
+    },
+    async 'Extensions.getNodeRpcInfo'(id: string): Promise<{ name: string; path: string }> {
+      invocations.push(['Extensions.getNodeRpcInfo', id])
+      return {
+        name: 'Git',
+        path: '/extensions/git/node/gitClient.js',
+      }
+    },
+  })
+
+  const rpc = await createNodeRpc({
+    id: 'git-client',
+  })
+
+  await rpc.dispose()
+  deepStrictEqual(invocations, [
+    ['Extensions.getNodeRpcInfo', 'git-client'],
+    ['ExtensionNodeRpc.create', 'Git', '/extensions/git/node/gitClient.js'],
+    ['ExtensionNodeRpc.dispose', 42],
+  ])
+})
+
+test('createNodeRpc requires an id or path', async () => {
+  await rejects(createNodeRpc({}), new TypeError('createNodeRpc requires an id or path'))
 })
 
 test('createRpc transfers a port and worker options', async () => {


### PR DESCRIPTION
Adds ID-based Node RPC creation to the extension API while retaining the existing explicit path form.