### PR TITLE
fix: support conditional access token refresh

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,5 +1,5 @@
 export { activate } from './parts/Activation/Activation.ts'
-export { getAccessToken } from './parts/Authentication/Authentication.ts'
+export { getAccessToken, type GetAccessTokenOptions } from './parts/Authentication/Authentication.ts'
 export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showQuickPick } from './parts/QuickPick/QuickPick.ts'

--- a/packages/extension-api/src/parts/Authentication/Authentication.ts
+++ b/packages/extension-api/src/parts/Authentication/Authentication.ts
@@ -1,5 +1,9 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
-export const getAccessToken = (): Promise<string> => {
-  return ExtensionManagementWorker.invoke('Extensions.getAccessToken')
+export interface GetAccessTokenOptions {
+  readonly refresh?: 'if-needed'
+}
+
+export const getAccessToken = (options: GetAccessTokenOptions = {}): Promise<string> => {
+  return ExtensionManagementWorker.invoke('Extensions.getAccessToken', options)
 }

--- a/packages/extension-api/test/parts/Authentication/Authentication.test.ts
+++ b/packages/extension-api/test/parts/Authentication/Authentication.test.ts
@@ -1,13 +1,9 @@
-import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
-import { strictEqual } from 'node:assert/strict'
+import { type DisposableMockRpc, ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { getAccessToken } from '../../../src/parts/Authentication/Authentication.ts'
 
-interface MockRpcDisposable {
-  [Symbol.dispose](): void
-}
-
-let mockRpc: MockRpcDisposable | undefined
+let mockRpc: DisposableMockRpc | undefined
 
 afterEach(() => {
   mockRpc?.[Symbol.dispose]()
@@ -22,4 +18,14 @@ test('getAccessToken invokes extension management worker', async () => {
   })
 
   strictEqual(await getAccessToken(), 'token-1')
+  strictEqual(
+    await getAccessToken({
+      refresh: 'if-needed',
+    }),
+    'token-1',
+  )
+  deepStrictEqual(mockRpc.invocations, [
+    ['Extensions.getAccessToken', {}],
+    ['Extensions.getAccessToken', { refresh: 'if-needed' }],
+  ])
 })


### PR DESCRIPTION
Adds an optional access-token refresh mode to the extension API and forwards it to extension management.