### PR TITLE
fix: execute extension view commands

### DIFF
--- a/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
@@ -13,7 +13,6 @@ import * as ExtensionApiFileSystemWorker from '../ExtensionApiFileSystemWorker/E
 import * as ExtensionHostBraceCompletion from '../ExtensionHostBraceCompletion/ExtensionHostBraceCompletion.ts'
 import * as ExtensionHostClosingTag from '../ExtensionHostClosingTag/ExtensionHostClosingTag.ts'
 import * as ExtensionHostCodeActions from '../ExtensionHostCodeActions/ExtensionHostCodeActions.ts'
-import * as ExtensionHostCommand from '../ExtensionHostCommand/ExtensionHostCommand.ts'
 import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.ts'
 import { executeCommentProvider } from '../ExtensionHostComment/ExtensionHostComment.ts'
 import * as ExtensionHostCompletion from '../ExtensionHostCompletion/ExtensionHostCompletion.ts'
@@ -96,7 +95,7 @@ export const commandMap: Record<string, CommandHandler> = {
   'ExtensionHostCodeActions.getSourceActions': ExtensionHostCodeActions.getSourceActions,
   [ExtensionHostCommandType.BraceCompletionExecuteBraceCompletionProvider]: ExtensionHostBraceCompletion.executeBraceCompletionProvider,
   [ExtensionHostCommandType.ClosingTagExecuteClosingTagProvider]: ExtensionHostClosingTag.executeClosingTagProvider,
-  [ExtensionHostCommandType.CommandExecute]: ExtensionHostCommand.executeCommand,
+  [ExtensionHostCommandType.CommandExecute]: ExecuteCommand.executeCommand,
   [ExtensionHostCommandType.CommentProviderExecute]: executeCommentProvider,
   [ExtensionHostCommandType.CompletionExecute]: ExtensionHostCompletion.executeCompletionProvider,
   [ExtensionHostCommandType.CompletionResolveExecute]: ExtensionHostCompletion.executeresolveCompletionItemProvider,

--- a/packages/extension-host-worker/src/parts/ExecuteCommand/ExecuteCommand.ts
+++ b/packages/extension-host-worker/src/parts/ExecuteCommand/ExecuteCommand.ts
@@ -1,4 +1,5 @@
 import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import * as ExtensionHostCommand from '../ExtensionHostCommand/ExtensionHostCommand.ts'
 
 const isCommandNotFoundError = (error: unknown): boolean => {
   return error instanceof Error && error.name === 'CommandNotFoundError'
@@ -10,6 +11,9 @@ export const executeCommand = async (id: string, ...args: readonly unknown[]): P
   } catch (error) {
     if (!isCommandNotFoundError(error)) {
       throw error
+    }
+    if (ExtensionHostCommand.hasCommand(id)) {
+      return ExtensionHostCommand.executeCommand(id, ...args)
     }
     return RendererWorker.invoke(id, ...args)
   }

--- a/packages/extension-host-worker/src/parts/ExtensionHostCommand/ExtensionHostCommand.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostCommand/ExtensionHostCommand.ts
@@ -52,6 +52,10 @@ export const executeCommand = async (id, ...args) => {
   }
 }
 
+export const hasCommand = (id: string): boolean => {
+  return id in state.commands
+}
+
 export const getRegisteredCommandIds = (): readonly string[] => {
   return Object.values(state.commands).map((command: any) => command.id)
 }

--- a/packages/extension-host-worker/src/parts/ExtensionHostStatusBar/ExtensionHostStatusBar.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostStatusBar/ExtensionHostStatusBar.ts
@@ -1,4 +1,4 @@
-import * as ExtensionHostCommand from '../ExtensionHostCommand/ExtensionHostCommand.ts'
+import * as ExecuteCommand from '../ExecuteCommand/ExecuteCommand.ts'
 import * as ExtensionHostSourceControl from '../ExtensionHostSourceControl/ExtensionHostSourceControl.ts'
 import * as Rpc from '../Rpc/Rpc.ts'
 import { VError } from '../VError/VError.ts'
@@ -43,7 +43,7 @@ export const registerChangeListener = () => {
 }
 
 export const executeCommand = async (name: string): Promise<void> => {
-  await ExtensionHostCommand.executeCommand(name)
+  await ExecuteCommand.executeCommand(name)
 }
 
 export interface StatusBarItemProvider {

--- a/packages/extension-host-worker/test/ExecuteCommand.test.ts
+++ b/packages/extension-host-worker/test/ExecuteCommand.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const extensionManagementInvoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+const rendererInvoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+  ExtensionManagementWorker: {
+    invoke: extensionManagementInvoke,
+  },
+  RendererWorker: {
+    invoke: rendererInvoke,
+  },
+}))
+
+const ExecuteCommand = await import('../src/parts/ExecuteCommand/ExecuteCommand.ts')
+const ExtensionHostCommand = await import('../src/parts/ExtensionHostCommand/ExtensionHostCommand.ts')
+const ExtensionHostStatusBar = await import('../src/parts/ExtensionHostStatusBar/ExtensionHostStatusBar.ts')
+
+const commandNotFound = (): Error => {
+  const error = new Error('command not found')
+  error.name = 'CommandNotFoundError'
+  return error
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  ExtensionHostCommand.reset()
+})
+
+test('executes an isolated extension command', async () => {
+  extensionManagementInvoke.mockResolvedValue('isolated result')
+
+  await expect(ExecuteCommand.executeCommand('git.stage', 'file.txt')).resolves.toBe('isolated result')
+
+  expect(extensionManagementInvoke).toHaveBeenCalledWith('Extensions.executeCommand', 'git.stage', 'file.txt')
+  expect(rendererInvoke).not.toHaveBeenCalled()
+})
+
+test('executes a status bar command through the shared command dispatcher', async () => {
+  extensionManagementInvoke.mockResolvedValue(undefined)
+
+  await ExtensionHostStatusBar.executeCommand('git.checkout')
+
+  expect(extensionManagementInvoke).toHaveBeenCalledWith('Extensions.executeCommand', 'git.checkout')
+})
+
+test('falls back to a registered legacy extension command', async () => {
+  extensionManagementInvoke.mockRejectedValue(commandNotFound())
+  const execute = jest.fn((_argument: string) => 'legacy result')
+  ExtensionHostCommand.registerCommand({
+    execute,
+    id: 'legacy.run',
+  })
+
+  await expect(ExecuteCommand.executeCommand('legacy.run', 'argument')).resolves.toBe('legacy result')
+
+  expect(execute).toHaveBeenCalledWith('argument')
+  expect(rendererInvoke).not.toHaveBeenCalled()
+})
+
+test('falls back to a renderer command', async () => {
+  extensionManagementInvoke.mockRejectedValue(commandNotFound())
+  rendererInvoke.mockResolvedValue('renderer result')
+
+  await expect(ExecuteCommand.executeCommand('Layout.toggleSideBar')).resolves.toBe('renderer result')
+
+  expect(rendererInvoke).toHaveBeenCalledWith('Layout.toggleSideBar')
+})
+
+test('preserves extension command errors', async () => {
+  const error = new TypeError('extension failed')
+  extensionManagementInvoke.mockRejectedValue(error)
+
+  await expect(ExecuteCommand.executeCommand('git.stage')).rejects.toBe(error)
+
+  expect(rendererInvoke).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Fix command dispatch for isolated extension commands triggered from views and status bar items. Preserve legacy extension and renderer command fallbacks, with focused regression coverage.