### PR TITLE
fix: forward code action context and edits

### DIFF
--- a/packages/extension-host-worker/src/parts/ExtensionHostCodeActions/ExtensionHostCodeActions.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostCodeActions/ExtensionHostCodeActions.ts
@@ -21,34 +21,40 @@ const {
 export { registerCodeActionProvider, reset }
 
 interface CodeAction {
+  readonly edits?: readonly unknown[]
   readonly kind: string
   readonly name: string
 }
 
-const executeCodeActionProvider = async (uid): Promise<readonly CodeAction[]> => {
+const executeCodeActionProvider = async (uid, ...args: readonly unknown[]): Promise<readonly CodeAction[]> => {
   if (!ExecuteIsolatedLanguageProvider.hasLegacyProvider(getProvider, uid)) {
-    const isolated = await ExecuteIsolatedLanguageProvider.execute('code action', 'provideCodeActions', uid)
+    const isolated = await ExecuteIsolatedLanguageProvider.execute('code action', 'provideCodeActions', uid, ...args)
     if (isolated.found) {
       return isolated.result as readonly CodeAction[]
     }
   }
-  return (await executeRegisteredCodeActionProvider(uid)) as unknown as readonly CodeAction[]
+  const executeProvider = executeRegisteredCodeActionProvider as unknown as (
+    uid: number,
+    ...args: readonly unknown[]
+  ) => Promise<readonly CodeAction[]>
+  return executeProvider(uid, ...args)
 }
 
 const toSourceAction = (languageId: string, action: CodeAction) => {
   return {
+    ...(action.edits && { edits: action.edits }),
     kind: action.kind,
     languageId,
     name: action.name,
   }
 }
 
-export const getSourceActions = async (uid) => {
+export const getSourceActions = async (uid, ...args: readonly unknown[]) => {
   const textDocument = ExtensionHostTextDocument.get(uid)
   if (!textDocument) {
     return []
   }
-  const actions = await executeCodeActionProvider(uid)
+  const actions = await executeCodeActionProvider(uid, ...args)
   return actions.map((action) => toSourceAction(textDocument.languageId, action))
 }
 

--- a/packages/extension-host-worker/test/ExtensionHostCodeActions.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostCodeActions.test.ts
@@ -19,6 +19,15 @@ beforeEach(() => {
 })
 
 test('getSourceActions returns serializable legacy code actions', async () => {
+  const provideCodeActions = jest.fn((_textDocument: unknown, _offset: number) => {
+    return [
+      {
+        execute() {},
+        kind: 'source.organizeImports',
+        name: 'Organize Imports',
+      },
+    ]
+  })
   TextDocument.setFiles([
     {
       id: 1,
@@ -29,28 +38,21 @@ test('getSourceActions returns serializable legacy code actions', async () => {
   ])
   ExtensionHostCodeActions.registerCodeActionProvider({
     languageId: 'typescript',
-    provideCodeActions() {
-      return [
-        {
-          execute() {},
-          kind: 'source.organizeImports',
-          name: 'Organize Imports',
-        },
-      ]
-    },
+    provideCodeActions,
   })
 
-  await expect(ExtensionHostCodeActions.getSourceActions(1)).resolves.toEqual([
+  await expect(ExtensionHostCodeActions.getSourceActions(1, 14)).resolves.toEqual([
     {
       kind: 'source.organizeImports',
       languageId: 'typescript',
       name: 'Organize Imports',
     },
   ])
+  expect(provideCodeActions).toHaveBeenCalledWith(TextDocument.get(1), 14)
   expect(executeMock).not.toHaveBeenCalled()
 })
 
-test('getSourceActions returns serializable isolated code actions', async () => {
+test('getSourceActions forwards arguments and returns isolated code action edits', async () => {
   TextDocument.setFiles([
     {
       id: 2,
@@ -63,20 +65,34 @@ test('getSourceActions returns serializable isolated code actions', async () => 
     found: true,
     result: [
       {
+        edits: [
+          {
+            endOffset: 28,
+            inserted: 'abort',
+            startOffset: 23,
+          },
+        ],
         kind: 'source.organizeImports',
         name: 'Organize Imports',
       },
     ],
   })
 
-  await expect(ExtensionHostCodeActions.getSourceActions(2)).resolves.toEqual([
+  await expect(ExtensionHostCodeActions.getSourceActions(2, 28)).resolves.toEqual([
     {
+      edits: [
+        {
+          endOffset: 28,
+          inserted: 'abort',
+          startOffset: 23,
+        },
+      ],
       kind: 'source.organizeImports',
       languageId: 'typescript',
       name: 'Organize Imports',
     },
   ])
-  expect(executeMock).toHaveBeenCalledWith('code action', 'provideCodeActions', 2)
+  expect(executeMock).toHaveBeenCalledWith('code action', 'provideCodeActions', 2, 28)
 })
 
 test('getSourceActions returns an empty array for a missing text document', async () => {


### PR DESCRIPTION
Forward code-action arguments such as the cursor offset to both legacy and isolated providers, and preserve returned edits in serializable source actions. This enables editor source actions backed by language-service quick fixes.