### PR TITLE
Expose extension-contributed JSON schemas

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from './parts/Formatting/Formatting.ts'
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
 export { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
+export { getJsonSchemas } from './parts/GetJsonSchemas/GetJsonSchemas.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'
 export {
@@ -121,6 +122,7 @@ export type {
 } from './parts/Formatting/Formatting.ts'
 export type { FileSystemDirent } from './parts/FileSystem/FileSystem.ts'
 export type { HandleExtensionManagementMessagePortOptions } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
+export type { JsonSchemaContribution } from './parts/JsonSchemaContribution/JsonSchemaContribution.ts'
 export type { HoverProvider, HoverProviderRegistrySnapshot, HoverResult, RegisteredHoverProvider } from './parts/Hover/Hover.ts'
 export type { LanguageServerOptions, LanguageServerRegistrySnapshot } from './parts/LanguageServer/LanguageServer.ts'
 export type { OutputChannel } from './parts/OutputChannelHandle/OutputChannelHandle.ts'

--- a/packages/extension-api/src/parts/GetJsonSchemas/GetJsonSchemas.ts
+++ b/packages/extension-api/src/parts/GetJsonSchemas/GetJsonSchemas.ts
@@ -1,0 +1,6 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import type { JsonSchemaContribution } from '../JsonSchemaContribution/JsonSchemaContribution.ts'
+
+export const getJsonSchemas = async (): Promise<readonly JsonSchemaContribution[]> => {
+  return ExtensionManagementWorker.invoke('Extensions.getJsonSchemas') as Promise<readonly JsonSchemaContribution[]>
+}

--- a/packages/extension-api/src/parts/JsonSchemaContribution/JsonSchemaContribution.ts
+++ b/packages/extension-api/src/parts/JsonSchemaContribution/JsonSchemaContribution.ts
@@ -1,0 +1,4 @@
+export interface JsonSchemaContribution {
+  readonly fileMatch: string | readonly string[]
+  readonly url: string
+}

--- a/packages/extension-api/test/parts/GetJsonSchemas/GetJsonSchemas.test.ts
+++ b/packages/extension-api/test/parts/GetJsonSchemas/GetJsonSchemas.test.ts
@@ -1,0 +1,42 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { getJsonSchemas } from '../../../src/parts/GetJsonSchemas/GetJsonSchemas.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('gets JSON schema contributions from the extension host', async () => {
+  const schemas = [{ fileMatch: 'package.json', url: '/extensions/prettier/schemas/package.schema.json' }]
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.getJsonSchemas'() {
+      return schemas
+    },
+  })
+
+  deepStrictEqual(await getJsonSchemas(), schemas)
+})
+
+test('preserves array file matches and remote URLs', async () => {
+  const schemas = [
+    {
+      fileMatch: ['.prettierrc', 'package.json'],
+      url: 'https://json.schemastore.org/prettierrc',
+    },
+  ]
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.getJsonSchemas'() {
+      return schemas
+    },
+  })
+
+  deepStrictEqual(await getJsonSchemas(), schemas)
+})

--- a/packages/extension-host-worker/src/parts/Api/Api.ts
+++ b/packages/extension-host-worker/src/parts/Api/Api.ts
@@ -39,6 +39,7 @@ import * as ExtensionHostView from '../ExtensionHostView/ExtensionHostView.ts'
 import * as ExtensionHostWebView from '../ExtensionHostWebView/ExtensionHostWebView.ts'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.ts'
 import * as ExtensionHostWorkspace from '../ExtensionHostWorkspace/ExtensionHostWorkspace.ts'
+import * as GetJsonSchemas from '../GetJsonSchemas/GetJsonSchemas.ts'
 import { FormattingError } from '../FormattingError/FormattingError.ts'
 import * as TextSearchResultType from '../TextSearchResultType/TextSearchResultType.ts'
 import { VError } from '../VError/VError.ts'
@@ -99,6 +100,7 @@ export const api = {
   getConfiguration: ExtensionHostConfiguration.getConfiguration,
   // Ajax
   getJson: ExtensionHostAjax.getJson,
+  getJsonSchemas: GetJsonSchemas.getJsonSchemas,
   // Get Offset
   getOffset: ExtensionHostGetOffset.getOffset,
   // Get Position

--- a/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
@@ -48,6 +48,7 @@ import * as GetColorThemeNames from '../GetColorThemeNames/GetColorThemeNames.ts
 import * as GetExtension from '../GetExtension/GetExtension.ts'
 import * as GetExtensions from '../GetExtensions/GetExtensions.ts'
 import * as GetIconThemeJson from '../GetIconThemeJson/GetIconThemeJson.ts'
+import * as GetJsonSchemas from '../GetJsonSchemas/GetJsonSchemas.ts'
 import * as GetRpcInfo from '../GetRpcInfo/GetRpcInfo.ts'
 import * as GetRuntimeStatus from '../GetRuntimeStatus/GetRuntimeStatus.ts'
 import * as GetWebViewInfo2 from '../GetWebViewInfo2/GetWebViewInfo2.ts'
@@ -178,6 +179,7 @@ export const commandMap: Record<string, CommandHandler> = {
   'Extensions.addWebExtension': AddWebExtension.addWebExtension,
   'Extensions.getExtension': GetExtension.getExtension,
   'Extensions.getExtensions': GetExtensions.getExtensions,
+  'Extensions.getJsonSchemas': GetJsonSchemas.getJsonSchemas,
   'Extensions.invalidateExtensionsCache': InvalidateExtensionsCache.invalidateExtensionsCache,
   'FileSystemFetch.chmod': FileSystemFetch.chmod,
   'FileSystemFetch.exists': FileSystemFetch.exists,

--- a/packages/extension-host-worker/src/parts/GetJsonSchemas/GetJsonSchemas.ts
+++ b/packages/extension-host-worker/src/parts/GetJsonSchemas/GetJsonSchemas.ts
@@ -1,0 +1,8 @@
+import * as GetExtensions from '../GetExtensions/GetExtensions.ts'
+import * as GetJsonSchemasFromExtension from '../GetJsonSchemasFromExtension/GetJsonSchemasFromExtension.ts'
+import * as Platform from '../Platform/Platform.ts'
+
+export const getJsonSchemas = async (): Promise<readonly any[]> => {
+  const extensions = await GetExtensions.getExtensions()
+  return extensions.flatMap((extension: any) => GetJsonSchemasFromExtension.getJsonSchemasFromExtension(extension, Platform.platform))
+}

--- a/packages/extension-host-worker/src/parts/GetJsonSchemasFromExtension/GetJsonSchemasFromExtension.ts
+++ b/packages/extension-host-worker/src/parts/GetJsonSchemasFromExtension/GetJsonSchemasFromExtension.ts
@@ -1,0 +1,31 @@
+import * as GetUrlPrefix from '../GetUrlPrefix/GetUrlPrefix.ts'
+
+const isAbsoluteUrl = (url: string): boolean => {
+  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:') || url.startsWith('/')
+}
+
+const resolveSchemaUrl = (platform: string, extensionPath: string, url: string): string => {
+  if (isAbsoluteUrl(url)) {
+    return url
+  }
+  const urlPrefix = GetUrlPrefix.getUrlPrefix(platform, extensionPath).replace(/\/$/, '')
+  const relativeUrl = url.replace(/^\.\//, '')
+  return `${urlPrefix}/${relativeUrl}`
+}
+
+export const getJsonSchemasFromExtension = (extension: any, platform: string): readonly any[] => {
+  if (!extension || !Array.isArray(extension.jsonValidation) || typeof extension.path !== 'string') {
+    return []
+  }
+  return extension.jsonValidation.flatMap((schema: any) => {
+    if (!schema || typeof schema.url !== 'string' || (!Array.isArray(schema.fileMatch) && typeof schema.fileMatch !== 'string')) {
+      return []
+    }
+    return [
+      {
+        fileMatch: schema.fileMatch,
+        url: resolveSchemaUrl(platform, extension.path, schema.url),
+      },
+    ]
+  })
+}

--- a/packages/extension-host-worker/test/GetJsonSchemasFromExtension.test.ts
+++ b/packages/extension-host-worker/test/GetJsonSchemasFromExtension.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@jest/globals'
+import * as GetJsonSchemasFromExtension from '../src/parts/GetJsonSchemasFromExtension/GetJsonSchemasFromExtension.ts'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
+
+test('returns no schemas for missing extension metadata', () => {
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension(undefined, PlatformType.Web)).toEqual([])
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension({}, PlatformType.Web)).toEqual([])
+})
+
+test('returns no schemas for invalid contributions', () => {
+  const extension = {
+    path: '/extensions/sample',
+    jsonValidation: [undefined, {}, { fileMatch: 'package.json' }, { url: './schema.json' }],
+  }
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension(extension, PlatformType.Web)).toEqual([])
+})
+
+test('resolves a relative schema url against the extension path', () => {
+  const extension = {
+    path: '/extensions/prettier',
+    jsonValidation: [{ fileMatch: 'package.json', url: './schemas/package.schema.json' }],
+  }
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension(extension, PlatformType.Web)).toEqual([
+    {
+      fileMatch: 'package.json',
+      url: '/extensions/prettier/schemas/package.schema.json',
+    },
+  ])
+})
+
+test('preserves remote schema urls and file match arrays', () => {
+  const extension = {
+    path: '/extensions/prettier',
+    jsonValidation: [{ fileMatch: ['.prettierrc', '.prettierrc.json'], url: 'https://json.schemastore.org/prettierrc' }],
+  }
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension(extension, PlatformType.Web)).toEqual([
+    {
+      fileMatch: ['.prettierrc', '.prettierrc.json'],
+      url: 'https://json.schemastore.org/prettierrc',
+    },
+  ])
+})
+
+test('uses the remote resource prefix outside the web platform', () => {
+  const extension = {
+    path: '/home/user/.lvce/extensions/prettier',
+    jsonValidation: [{ fileMatch: 'package.json', url: 'schemas/package.schema.json' }],
+  }
+  expect(GetJsonSchemasFromExtension.getJsonSchemasFromExtension(extension, PlatformType.Remote)).toEqual([
+    {
+      fileMatch: 'package.json',
+      url: '/remote/home/user/.lvce/extensions/prettier/schemas/package.schema.json',
+    },
+  ])
+})


### PR DESCRIPTION
## Summary\n- normalize jsonValidation contributions from installed extensions\n- expose them through getJsonSchemas in the isolated extension API\n- add host and API unit coverage\n\n## Tests\n- extension API test suite\n- JSON schema extraction tests\n- build and type-check