### PR TITLE
feature: support direct view event handlers

### DIFF
--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -11,6 +11,8 @@ export interface ViewContext {
 }
 
 export interface ViewEvent {
+  readonly args?: readonly unknown[]
+  readonly handler?: string
   readonly name?: string
   readonly type: string
   readonly value?: unknown

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -540,7 +540,13 @@ export const dispatchViewEvent = async (uid: number, event: ViewEvent): Promise<
   const instanceUids = instanceUidsByView[contextViewIds[uid]]
   instanceUids.delete(uid)
   instanceUids.add(uid)
-  if (typeof instance.handleEvent === 'function') {
+  if (event.handler) {
+    const handler = (instance as unknown as Readonly<Record<string, unknown>>)[event.handler]
+    if (typeof handler !== 'function') {
+      throw new TypeError(`view event handler ${event.handler} is not a function`)
+    }
+    await Reflect.apply(handler, instance, event.args || [])
+  } else if (typeof instance.handleEvent === 'function') {
     await instance.handleEvent(event)
   }
   const result = await renderPatches(uid, instance)

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -541,6 +541,63 @@ test('dispatchViewEvent returns patches after handling event', async () => {
   strictEqual(result.type, 'setPatches')
 })
 
+test('dispatchViewEvent invokes a direct event handler', async () => {
+  let value = ''
+  registerView({
+    create() {
+      return {
+        handleInput(name: string, inputValue: string) {
+          value = `${name}:${inputValue}`
+        },
+        render() {
+          return [
+            {
+              childCount: 0,
+              text: value,
+              type: 4,
+            },
+          ] as any
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await createViewInstance('sample.views.testing', 1)
+  const result = await dispatchViewEvent(1, {
+    args: ['title', 'abc'],
+    handler: 'handleInput',
+    type: 'command',
+  })
+
+  strictEqual(result.type, 'setPatches')
+  strictEqual(value, 'title:abc')
+})
+
+test('dispatchViewEvent rejects a missing direct event handler', async () => {
+  registerView({
+    create() {
+      return {
+        render() {
+          return []
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await createViewInstance('sample.views.testing', 1)
+  await rejects(
+    dispatchViewEvent(1, {
+      handler: 'handleInput',
+      type: 'command',
+    }),
+    /view event handler handleInput is not a function/,
+  )
+})
+
 test('renderViewInstance returns patches after state changes', async () => {
   let value = ''
   registerView({

--- a/packages/extension-host-worker/src/parts/ExtensionHostView/ExtensionHostView.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostView/ExtensionHostView.ts
@@ -2,6 +2,8 @@ import { diffTree, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VError } from '../VError/VError.ts'
 
 export interface ViewEvent {
+  readonly args?: readonly unknown[]
+  readonly handler?: string
   readonly name?: string
   readonly type: string
   readonly value?: unknown
@@ -143,7 +145,13 @@ export const createViewInstance = async (viewId: string, uid: number, context?: 
 
 export const dispatchViewEvent = async (uid: number, event: ViewEvent): Promise<ViewRenderResult> => {
   const instance = getVirtualDomInstance(uid)
-  if (typeof instance.handleEvent === 'function') {
+  if (event.handler) {
+    const handler = (instance as unknown as Readonly<Record<string, unknown>>)[event.handler]
+    if (typeof handler !== 'function') {
+      throw new TypeError(`view event handler ${event.handler} is not a function`)
+    }
+    await Reflect.apply(handler, instance, event.args || [])
+  } else if (typeof instance.handleEvent === 'function') {
     await instance.handleEvent(event)
   }
   const oldDom = state.renderedDoms[uid] || []

--- a/packages/extension-host-worker/test/ExtensionHostView.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostView.test.ts
@@ -66,6 +66,56 @@ test('dispatchViewEvent - returns patches after handling event', async () => {
   expect(result.type).toBe('setPatches')
 })
 
+test('dispatchViewEvent - invokes a direct event handler', async () => {
+  let value = ''
+  ExtensionHostView.registerView({
+    create() {
+      return {
+        handleInput(name: string, inputValue: string) {
+          value = `${name}:${inputValue}`
+        },
+        render() {
+          return [textNode(value)]
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await ExtensionHostView.createViewInstance('sample.views.testing', 1)
+  const result = await ExtensionHostView.dispatchViewEvent(1, {
+    args: ['title', 'abc'],
+    handler: 'handleInput',
+    type: 'command',
+  })
+
+  expect(result.type).toBe('setPatches')
+  expect(value).toBe('title:abc')
+})
+
+test('dispatchViewEvent - rejects a missing direct event handler', async () => {
+  ExtensionHostView.registerView({
+    create() {
+      return {
+        render() {
+          return []
+        },
+      }
+    },
+    id: 'sample.views.testing',
+    kind: 'virtualDom',
+  })
+
+  await ExtensionHostView.createViewInstance('sample.views.testing', 1)
+  await expect(
+    ExtensionHostView.dispatchViewEvent(1, {
+      handler: 'handleInput',
+      type: 'command',
+    }),
+  ).rejects.toThrow(new TypeError('view event handler handleInput is not a function'))
+})
+
 test('renderTitle - returns dynamic title after lifecycle updates', async () => {
   let title = 'Testing'
   ExtensionHostView.registerView({


### PR DESCRIPTION
## Summary

Allow virtual DOM view event metadata to invoke named instance handlers with positional arguments while preserving the existing generic event path.