### PR TITLE
feature: expose runtime platform to extensions

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -27,6 +27,7 @@ export {
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
 export { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
+export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
 export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'
 export {
   registerBraceCompletionProvider,

--- a/packages/extension-api/src/parts/Platform/Platform.ts
+++ b/packages/extension-api/src/parts/Platform/Platform.ts
@@ -1,0 +1,19 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export type Platform = 'electron' | 'remote' | 'test' | 'web'
+
+export const getPlatform = async (): Promise<Platform> => {
+  const platform = await executeCommand('Layout.getPlatform')
+  switch (platform) {
+    case 1:
+      return 'web'
+    case 2:
+      return 'electron'
+    case 3:
+      return 'remote'
+    case 4:
+      return 'test'
+    default:
+      throw new TypeError(`Unknown platform: ${platform}`)
+  }
+}

--- a/packages/extension-api/test/parts/Platform/Platform.test.ts
+++ b/packages/extension-api/test/parts/Platform/Platform.test.ts
@@ -1,0 +1,48 @@
+import { type DisposableMockRpc, ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { rejects, strictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { getPlatform } from '../../../src/parts/Platform/Platform.ts'
+
+let mockRpc: DisposableMockRpc | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+const mockPlatform = (platform: number): void => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string): Promise<number> {
+      strictEqual(id, 'Layout.getPlatform')
+      return platform
+    },
+  })
+}
+
+test('returns web platform', async () => {
+  mockPlatform(1)
+  strictEqual(await getPlatform(), 'web')
+})
+
+test('returns electron platform', async () => {
+  mockPlatform(2)
+  strictEqual(await getPlatform(), 'electron')
+})
+
+test('returns remote platform', async () => {
+  mockPlatform(3)
+  strictEqual(await getPlatform(), 'remote')
+})
+
+test('returns test platform', async () => {
+  mockPlatform(4)
+  strictEqual(await getPlatform(), 'test')
+})
+
+test('throws for an unknown platform', async () => {
+  mockPlatform(99)
+  await rejects(getPlatform(), {
+    message: 'Unknown platform: 99',
+    name: 'TypeError',
+  })
+})


### PR DESCRIPTION
Adds a public getPlatform API that reports web, electron, remote, or test using the renderer's existing runtime platform command.