### PR TITLE
feature: support lazy source control diff uris

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -25,6 +25,12 @@ export {
   resetFormattingProviderRegistry,
 } from './parts/Formatting/Formatting.ts'
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
+export {
+  executeFileSystemProviderReadFile,
+  getFileSystemProviderRegistrySnapshot,
+  registerFileSystemProvider,
+  resetFileSystemProviderRegistry,
+} from './parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
 export { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
@@ -53,6 +59,7 @@ export {
   executeSourceControlGetChangedFiles,
   executeSourceControlGetFeatures,
   executeSourceControlGetFileBefore,
+  executeSourceControlGetFileBeforeUri,
   executeSourceControlGetFileDecorations,
   executeSourceControlGetGroups,
   executeSourceControlIsActive,
@@ -121,6 +128,9 @@ export type {
   RegisteredFormattingProvider,
 } from './parts/Formatting/Formatting.ts'
 export type { FileSystemDirent } from './parts/FileSystem/FileSystem.ts'
+export type { FileSystemProvider } from './parts/FileSystemProvider/FileSystemProvider.ts'
+export type { FileSystemProviderRegistrySnapshot } from './parts/FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts'
+export type { RegisteredFileSystemProvider } from './parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts'
 export type { HandleExtensionManagementMessagePortOptions } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 export type { HoverProvider, HoverProviderRegistrySnapshot, HoverResult, RegisteredHoverProvider } from './parts/Hover/Hover.ts'
 export type { LanguageServerOptions, LanguageServerRegistrySnapshot } from './parts/LanguageServer/LanguageServer.ts'

--- a/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
+++ b/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
@@ -1,6 +1,7 @@
 import { executeCommand, getCommandRegistrySnapshot } from '../CommandRegistry/CommandRegistry.ts'
 import { executeCompletionProvider, executeResolveCompletionItemProvider, getCompletionProviderRegistrySnapshot } from '../Completion/Completion.ts'
 import { executeDiagnosticProvider, getDiagnosticProviderRegistrySnapshot } from '../Diagnostic/Diagnostic.ts'
+import { executeFileSystemProviderReadFile, getFileSystemProviderRegistrySnapshot } from '../FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
 import { executeFormattingProvider, getFormattingProviderRegistrySnapshot } from '../Formatting/Formatting.ts'
 import { getStatusBarItems } from '../GetStatusBarItems/GetStatusBarItems.ts'
 import { executeHoverProvider, getHoverProviderRegistrySnapshot } from '../Hover/Hover.ts'
@@ -16,6 +17,7 @@ import {
   executeSourceControlGetChangedFiles,
   executeSourceControlGetFeatures,
   executeSourceControlGetFileBefore,
+  executeSourceControlGetFileBeforeUri,
   executeSourceControlGetFileDecorations,
   executeSourceControlGetGroups,
   executeSourceControlIsActive,
@@ -41,6 +43,7 @@ export const commandMap = {
   'ExtensionApi.executeCommand': executeCommand,
   'ExtensionApi.executeCompletionProvider': executeCompletionProvider,
   'ExtensionApi.executeDiagnosticProvider': executeDiagnosticProvider,
+  'ExtensionApi.executeFileSystemProviderReadFile': executeFileSystemProviderReadFile,
   'ExtensionApi.executeFormattingProvider': executeFormattingProvider,
   'ExtensionApi.executeHoverProvider': executeHoverProvider,
   'ExtensionApi.executeLanguageProvider': executeLanguageProvider,
@@ -54,6 +57,7 @@ export const commandMap = {
   'ExtensionApi.executeSourceControlGetChangedFiles': executeSourceControlGetChangedFiles,
   'ExtensionApi.executeSourceControlGetFeatures': executeSourceControlGetFeatures,
   'ExtensionApi.executeSourceControlGetFileBefore': executeSourceControlGetFileBefore,
+  'ExtensionApi.executeSourceControlGetFileBeforeUri': executeSourceControlGetFileBeforeUri,
   'ExtensionApi.executeSourceControlGetFileDecorations': executeSourceControlGetFileDecorations,
   'ExtensionApi.executeSourceControlGetGroups': executeSourceControlGetGroups,
   'ExtensionApi.executeSourceControlIsActive': executeSourceControlIsActive,
@@ -61,6 +65,7 @@ export const commandMap = {
   'ExtensionApi.getCommandRegistrySnapshot': getCommandRegistrySnapshot,
   'ExtensionApi.getCompletionProviderRegistrySnapshot': getCompletionProviderRegistrySnapshot,
   'ExtensionApi.getDiagnosticProviderRegistrySnapshot': getDiagnosticProviderRegistrySnapshot,
+  'ExtensionApi.getFileSystemProviderRegistrySnapshot': getFileSystemProviderRegistrySnapshot,
   'ExtensionApi.getFormattingProviderRegistrySnapshot': getFormattingProviderRegistrySnapshot,
   'ExtensionApi.getHoverProviderRegistrySnapshot': getHoverProviderRegistrySnapshot,
   'ExtensionApi.getLanguageServerRegistrySnapshot': getLanguageServerRegistrySnapshot,

--- a/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
+++ b/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
@@ -1,0 +1,4 @@
+export interface FileSystemProvider {
+  readonly id: string
+  readonly readFile: (uri: string) => string | Promise<string>
+}

--- a/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
@@ -1,0 +1,61 @@
+import type { Disposable } from '../Disposable/Disposable.ts'
+import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
+import type { FileSystemProvider } from '../FileSystemProvider/FileSystemProvider.ts'
+import type { FileSystemProviderRegistrySnapshot } from '../FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts'
+import type { RegisteredFileSystemProvider } from '../RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts'
+
+const providers: Record<string, RegisteredFileSystemProvider> = Object.create(null)
+
+const assertFileSystemProvider = (provider: FileSystemProvider): void => {
+  if (!provider) {
+    throw new ExtensionApiError('file system provider is not defined')
+  }
+  if (typeof provider.id !== 'string' || provider.id.length === 0) {
+    throw new ExtensionApiError('file system provider is missing id')
+  }
+  if (typeof provider.readFile !== 'function') {
+    throw new ExtensionApiError(`file system provider ${provider.id} is missing readFile function`)
+  }
+  if (provider.id in providers) {
+    throw new ExtensionApiError(`file system provider ${provider.id} is already registered`)
+  }
+}
+
+const getProvider = (id: string): RegisteredFileSystemProvider => {
+  const provider = providers[id]
+  if (!provider) {
+    throw new ExtensionApiError(`file system provider ${id} not found`)
+  }
+  return provider
+}
+
+export const executeFileSystemProviderReadFile = async (id: string, uri: string): Promise<string> => {
+  return getProvider(id).readFile(uri)
+}
+
+export const getFileSystemProviderRegistrySnapshot = (): FileSystemProviderRegistrySnapshot => {
+  return {
+    providers: Object.values(providers).map((provider) => ({
+      id: provider.id,
+    })),
+  }
+}
+
+export const registerFileSystemProvider = (provider: FileSystemProvider): Disposable => {
+  assertFileSystemProvider(provider)
+  providers[provider.id] = {
+    id: provider.id,
+    readFile: (uri) => provider.readFile(uri),
+  }
+  return {
+    dispose(): void {
+      delete providers[provider.id]
+    },
+  }
+}
+
+export const resetFileSystemProviderRegistry = (): void => {
+  for (const id of Object.keys(providers)) {
+    delete providers[id]
+  }
+}

--- a/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
@@ -1,8 +1,8 @@
 import type { Disposable } from '../Disposable/Disposable.ts'
-import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
 import type { FileSystemProvider } from '../FileSystemProvider/FileSystemProvider.ts'
 import type { FileSystemProviderRegistrySnapshot } from '../FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts'
 import type { RegisteredFileSystemProvider } from '../RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts'
+import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
 
 const providers: Record<string, RegisteredFileSystemProvider> = Object.create(null)
 

--- a/packages/extension-api/src/parts/FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts
@@ -1,0 +1,5 @@
+export interface FileSystemProviderRegistrySnapshot {
+  readonly providers: readonly {
+    readonly id: string
+  }[]
+}

--- a/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
+++ b/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
@@ -1,0 +1,4 @@
+export interface RegisteredFileSystemProvider {
+  readonly id: string
+  readonly readFile: (uri: string) => string | Promise<string>
+}

--- a/packages/extension-api/src/parts/RegisteredSourceControlProvider/RegisteredSourceControlProvider.ts
+++ b/packages/extension-api/src/parts/RegisteredSourceControlProvider/RegisteredSourceControlProvider.ts
@@ -7,6 +7,7 @@ export interface RegisteredSourceControlProvider {
   readonly getChangedFiles: () => readonly unknown[] | Promise<readonly unknown[]>
   readonly getFeatures?: () => unknown | Promise<unknown>
   readonly getFileBefore?: (uri: string) => unknown | Promise<unknown>
+  readonly getFileBeforeUri?: (uri: string) => string | Promise<string>
   readonly getFileDecorations?: (uris: readonly string[]) => unknown | Promise<unknown>
   readonly getGroups?: (cwd: string) => unknown | Promise<unknown>
   readonly id: string

--- a/packages/extension-api/src/parts/SourceControl/SourceControl.ts
+++ b/packages/extension-api/src/parts/SourceControl/SourceControl.ts
@@ -7,6 +7,7 @@ export {
   executeSourceControlGetChangedFiles,
   executeSourceControlGetFeatures,
   executeSourceControlGetFileBefore,
+  executeSourceControlGetFileBeforeUri,
   executeSourceControlGetFileDecorations,
   executeSourceControlGetGroups,
   executeSourceControlIsActive,

--- a/packages/extension-api/src/parts/SourceControlProvider/SourceControlProvider.ts
+++ b/packages/extension-api/src/parts/SourceControlProvider/SourceControlProvider.ts
@@ -7,6 +7,7 @@ export interface SourceControlProvider {
   readonly getChangedFiles: () => readonly unknown[] | Promise<readonly unknown[]>
   readonly getFeatures?: () => unknown | Promise<unknown>
   readonly getFileBefore?: (uri: string) => unknown | Promise<unknown>
+  readonly getFileBeforeUri?: (uri: string) => string | Promise<string>
   readonly getFileDecorations?: (uris: readonly string[]) => unknown | Promise<unknown>
   readonly getGroups?: (cwd: string) => unknown | Promise<unknown>
   readonly id: string

--- a/packages/extension-api/src/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.ts
+++ b/packages/extension-api/src/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.ts
@@ -152,7 +152,13 @@ export const executeSourceControlGetFileBeforeUri = async (id: string, uri: stri
     return provider.getFileBeforeUri(uri)
   }
   const content = await provider.getFileBefore?.(uri)
-  return `data://${content ?? ''}`
+  if (content === undefined) {
+    return 'data://'
+  }
+  if (typeof content !== 'string') {
+    throw new ExtensionApiError(`source control provider ${id} returned an invalid getFileBefore result`)
+  }
+  return `data://${content}`
 }
 
 export const executeSourceControlGetFileDecorations = async (id: string, uris: readonly string[]): Promise<unknown> => {

--- a/packages/extension-api/src/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.ts
+++ b/packages/extension-api/src/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.ts
@@ -14,6 +14,7 @@ const optionalMethods = [
   'getBadgeCount',
   'getFeatures',
   'getFileBefore',
+  'getFileBeforeUri',
   'getFileDecorations',
   'getGroups',
   'isActive',
@@ -83,6 +84,9 @@ const mapSourceControlProvider = (provider: SourceControlProvider): RegisteredSo
   if (provider.getFileBefore) {
     registeredProvider.getFileBefore = (uri) => provider.getFileBefore!(uri)
   }
+  if (provider.getFileBeforeUri) {
+    registeredProvider.getFileBeforeUri = (uri) => provider.getFileBeforeUri!(uri)
+  }
   if (provider.getFileDecorations) {
     registeredProvider.getFileDecorations = (uris) => provider.getFileDecorations!(uris)
   }
@@ -140,6 +144,15 @@ export const executeSourceControlGetFeatures = async (id: string): Promise<unkno
 
 export const executeSourceControlGetFileBefore = async (id: string, uri: string): Promise<unknown> => {
   return getProvider(id).getFileBefore?.(uri)
+}
+
+export const executeSourceControlGetFileBeforeUri = async (id: string, uri: string): Promise<string> => {
+  const provider = getProvider(id)
+  if (provider.getFileBeforeUri) {
+    return provider.getFileBeforeUri(uri)
+  }
+  const content = await provider.getFileBefore?.(uri)
+  return `data://${content ?? ''}`
 }
 
 export const executeSourceControlGetFileDecorations = async (id: string, uris: readonly string[]): Promise<unknown> => {

--- a/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
+++ b/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
@@ -27,3 +27,8 @@ test('commandMap keeps completion, diagnostic and formatting provider commands',
   strictEqual(typeof commandMap['ExtensionApi.executeFormattingProvider'], 'function')
   strictEqual(typeof commandMap['ExtensionApi.executeResolveCompletionItemProvider'], 'function')
 })
+
+test('commandMap exposes file system provider commands', () => {
+  strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderReadFile'], 'function')
+  strictEqual(typeof commandMap['ExtensionApi.getFileSystemProviderRegistrySnapshot'], 'function')
+})

--- a/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
@@ -1,0 +1,43 @@
+import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import {
+  executeFileSystemProviderReadFile,
+  getFileSystemProviderRegistrySnapshot,
+  registerFileSystemProvider,
+  resetFileSystemProviderRegistry,
+} from '../../../src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
+
+afterEach(() => {
+  resetFileSystemProviderRegistry()
+})
+
+test('registerFileSystemProvider registers and reads files', async () => {
+  const disposable = registerFileSystemProvider({
+    id: 'git-file-before',
+    readFile(uri) {
+      return `before:${uri}`
+    },
+  })
+
+  deepStrictEqual(getFileSystemProviderRegistrySnapshot(), {
+    providers: [{ id: 'git-file-before' }],
+  })
+  strictEqual(await executeFileSystemProviderReadFile('git-file-before', 'file:///workspace/file.txt'), 'before:file:///workspace/file.txt')
+
+  disposable.dispose()
+  deepStrictEqual(getFileSystemProviderRegistrySnapshot(), { providers: [] })
+})
+
+test('registerFileSystemProvider rejects a missing readFile function', () => {
+  throws(() => {
+    registerFileSystemProvider({
+      id: 'invalid',
+      // @ts-expect-error testing invalid provider shape
+      readFile: undefined,
+    })
+  }, /file system provider invalid is missing readFile function/)
+})
+
+test('executeFileSystemProviderReadFile rejects an unknown provider', async () => {
+  await rejects(executeFileSystemProviderReadFile('missing', 'file:///workspace/file.txt'), /file system provider missing not found/)
+})

--- a/packages/extension-api/test/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual, throws } from 'node:assert/strict'
+import { rejects, strictEqual, throws } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import {
   executeSourceControlGetFileBeforeUri,
@@ -36,6 +36,23 @@ test('executeSourceControlGetFileBeforeUri wraps legacy content in a data uri', 
   })
 
   strictEqual(await executeSourceControlGetFileBeforeUri('legacy', 'file:///workspace/file.txt'), 'data://before content')
+})
+
+test('executeSourceControlGetFileBeforeUri rejects invalid legacy content', async () => {
+  registerSourceControlProvider({
+    getChangedFiles() {
+      return []
+    },
+    getFileBefore() {
+      return {}
+    },
+    id: 'legacy',
+  })
+
+  await rejects(
+    executeSourceControlGetFileBeforeUri('legacy', 'file:///workspace/file.txt'),
+    /source control provider legacy returned an invalid getFileBefore result/,
+  )
 })
 
 test('registerSourceControlProvider rejects an invalid getFileBeforeUri', () => {

--- a/packages/extension-api/test/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.test.ts
@@ -1,0 +1,52 @@
+import { strictEqual, throws } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import {
+  executeSourceControlGetFileBeforeUri,
+  registerSourceControlProvider,
+  resetSourceControlProviderRegistry,
+} from '../../../src/parts/SourceControlProviderRegistry/SourceControlProviderRegistry.ts'
+
+afterEach(() => {
+  resetSourceControlProviderRegistry()
+})
+
+test('executeSourceControlGetFileBeforeUri uses the provider uri', async () => {
+  registerSourceControlProvider({
+    getChangedFiles() {
+      return []
+    },
+    getFileBeforeUri(uri) {
+      return `git-file-before://${uri}`
+    },
+    id: 'git',
+  })
+
+  strictEqual(await executeSourceControlGetFileBeforeUri('git', 'file:///workspace/file.txt'), 'git-file-before://file:///workspace/file.txt')
+})
+
+test('executeSourceControlGetFileBeforeUri wraps legacy content in a data uri', async () => {
+  registerSourceControlProvider({
+    getChangedFiles() {
+      return []
+    },
+    getFileBefore() {
+      return 'before content'
+    },
+    id: 'legacy',
+  })
+
+  strictEqual(await executeSourceControlGetFileBeforeUri('legacy', 'file:///workspace/file.txt'), 'data://before content')
+})
+
+test('registerSourceControlProvider rejects an invalid getFileBeforeUri', () => {
+  throws(() => {
+    registerSourceControlProvider({
+      getChangedFiles() {
+        return []
+      },
+      // @ts-expect-error testing invalid provider shape
+      getFileBeforeUri: 'git-file-before://',
+      id: 'git',
+    })
+  }, /source control provider git has invalid getFileBeforeUri function/)
+})

--- a/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-host-worker/src/parts/CommandMap/CommandMap.ts
@@ -131,6 +131,7 @@ export const commandMap: Record<string, CommandHandler> = {
   [ExtensionHostCommandType.SourceControlGetFeatures]: ExtensionHostSourceControl.getFeatures,
   [ExtensionHostCommandType.SourceControlGetFileBefore]: ExtensionHostSourceControl.getFileBefore,
   [ExtensionHostCommandType.SourceControlGetFileBefore2]: ExtensionHostSourceControl.getFileBefore,
+  [ExtensionHostCommandType.SourceControlGetFileBeforeUri]: ExtensionHostSourceControl.getFileBeforeUri,
   [ExtensionHostCommandType.SourceControlGetFileDecorations]: ExtensionHostSourceControl.getFileDecorations,
   [ExtensionHostCommandType.SourceControlGetGroups]: ExtensionHostSourceControl.getGroups,
   [ExtensionHostCommandType.StatusBarExecuteCommand]: ExtensionHostStatusBar.executeCommand,

--- a/packages/extension-host-worker/src/parts/ExecuteIsolatedFileSystemProvider/ExecuteIsolatedFileSystemProvider.ts
+++ b/packages/extension-host-worker/src/parts/ExecuteIsolatedFileSystemProvider/ExecuteIsolatedFileSystemProvider.ts
@@ -1,0 +1,24 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+
+interface FileSystemProviderResult {
+  readonly found: boolean
+  readonly result?: unknown
+}
+
+const isUnavailableError = (error: unknown): boolean => {
+  return (
+    (error instanceof Error && error.name === 'CommandNotFoundError') ||
+    (error instanceof TypeError && error.message === "Cannot read properties of undefined (reading 'invoke')")
+  )
+}
+
+export const execute = async (providerId: string, uri: string): Promise<FileSystemProviderResult> => {
+  try {
+    return await ExtensionManagementWorker.invoke('Extensions.executeFileSystemProviderReadFile', providerId, uri)
+  } catch (error) {
+    if (isUnavailableError(error)) {
+      return { found: false }
+    }
+    throw error
+  }
+}

--- a/packages/extension-host-worker/src/parts/ExtensionHostCommandType/ExtensionHostCommandType.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostCommandType/ExtensionHostCommandType.ts
@@ -36,6 +36,7 @@ export const SourceControlGetEnabledProviderIds = 'ExtensionHostSourceControl.ge
 export const SourceControlGetFeatures = 'ExtensionHostSourceControl.getFeatures'
 export const SourceControlGetFileBefore = 'ExtensionHostSourceControl.GetFileBefore'
 export const SourceControlGetFileBefore2 = 'ExtensionHostSourceControl.getFileBefore'
+export const SourceControlGetFileBeforeUri = 'ExtensionHostSourceControl.getFileBeforeUri'
 export const SourceControlGetFileDecorations = 'ExtensionHostSourceControl.getFileDecorations'
 export const SourceControlGetGroups = 'ExtensionHostSourceControl.getGroups'
 export const StatusBarExecuteCommand = 'ExtensionHostStatusBar.executeCommand'

--- a/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
@@ -1,3 +1,4 @@
+import * as ExecuteIsolatedFileSystemProvider from '../ExecuteIsolatedFileSystemProvider/ExecuteIsolatedFileSystemProvider.ts'
 import * as FileSystemProviderState from '../FileSystemProviderState/FileSystemProviderState.ts'
 import * as Rpc from '../Rpc/Rpc.ts'
 import { VError } from '../VError/VError.ts'
@@ -20,8 +21,15 @@ export const readDirWithFileTypes = async (protocol, path) => {
 
 export const readFile = async (protocol, path) => {
   try {
-    const provider = FileSystemProviderState.get(protocol)
-    return await provider.readFile(path)
+    const provider = FileSystemProviderState.getOptional(protocol)
+    if (provider) {
+      return await provider.readFile(path)
+    }
+    const isolated = await ExecuteIsolatedFileSystemProvider.execute(protocol, path)
+    if (isolated.found) {
+      return isolated.result
+    }
+    return await FileSystemProviderState.get(protocol).readFile(path)
   } catch (error) {
     throw new VError(error, 'Failed to execute file system provider')
   }

--- a/packages/extension-host-worker/src/parts/ExtensionHostSourceControl/ExtensionHostSourceControl.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostSourceControl/ExtensionHostSourceControl.ts
@@ -70,6 +70,28 @@ export const getFileBefore = async (providerId, uri) => {
   return getProvider(providerId).getFileBefore(uri)
 }
 
+const getFileBeforeUriFromProvider = async (provider, uri): Promise<string> => {
+  if (typeof provider.getFileBeforeUri === 'function') {
+    return provider.getFileBeforeUri(uri)
+  }
+  const content = await provider.getFileBefore?.(uri)
+  return `data://${content ?? ''}`
+}
+
+export const getFileBeforeUri = async (providerId, uri): Promise<string> => {
+  Assert.string(providerId)
+  Assert.string(uri)
+  const provider = state.providers[providerId]
+  if (provider) {
+    return getFileBeforeUriFromProvider(provider, uri)
+  }
+  const isolated = await ExecuteIsolatedSourceControlProvider.execute(providerId, 'executeSourceControlGetFileBeforeUri', uri)
+  if (isolated.found) {
+    return isolated.result as string
+  }
+  return getFileBeforeUriFromProvider(getProvider(providerId), uri)
+}
+
 const getGroupsFromProvider = async (provider, cwd) => {
   if (provider.getGroups) {
     return provider.getGroups(cwd)

--- a/packages/extension-host-worker/src/parts/FileSystemProviderState/FileSystemProviderState.ts
+++ b/packages/extension-host-worker/src/parts/FileSystemProviderState/FileSystemProviderState.ts
@@ -11,6 +11,10 @@ export const get = (protocol) => {
   return provider
 }
 
+export const getOptional = (protocol) => {
+  return fileSystemProviderMap[protocol]
+}
+
 export const set = (id, provider) => {
   if (!id) {
     throw new Error('Failed to register file system provider: missing id')

--- a/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionHostFileSystem from '../src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts'
 import * as FileSystemProviderState from '../src/parts/FileSystemProviderState/FileSystemProviderState.ts'
 
@@ -19,6 +20,22 @@ test('registerFileSystemProvider - error - missing id', () => {
       },
     })
   }).toThrow(new Error('Failed to register file system provider: missing id'))
+})
+
+test('readFile - isolated provider', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeFileSystemProviderReadFile': async (providerId: string, uri: string) => {
+      return {
+        found: true,
+        result: `${providerId}:${uri}`,
+      }
+    },
+  })
+
+  await expect(ExtensionHostFileSystem.readFile('git-file-before', 'file:///workspace/file.txt')).resolves.toBe(
+    'git-file-before:file:///workspace/file.txt',
+  )
+  expect(mockRpc.invocations).toEqual([['Extensions.executeFileSystemProviderReadFile', 'git-file-before', 'file:///workspace/file.txt']])
 })
 
 test('readDirWithFileTypes', async () => {

--- a/packages/extension-host-worker/test/ExtensionHostSourceControl.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostSourceControl.test.ts
@@ -114,6 +114,45 @@ test('getChangedFiles - isolated provider', async () => {
   expect(invocations).toEqual([['git', 'executeSourceControlGetChangedFiles']])
 })
 
+test('getFileBeforeUri', async () => {
+  ExtensionHostSourceControl.registerSourceControlProvider({
+    getFileBeforeUri(uri: string) {
+      return `git-file-before://${uri}`
+    },
+    id: 'git',
+  })
+
+  await expect(ExtensionHostSourceControl.getFileBeforeUri('git', 'file:///workspace/file.txt')).resolves.toBe(
+    'git-file-before://file:///workspace/file.txt',
+  )
+})
+
+test('getFileBeforeUri - legacy content provider', async () => {
+  ExtensionHostSourceControl.registerSourceControlProvider({
+    getFileBefore() {
+      return 'before content'
+    },
+    id: 'legacy',
+  })
+
+  await expect(ExtensionHostSourceControl.getFileBeforeUri('legacy', 'file:///workspace/file.txt')).resolves.toBe('data://before content')
+})
+
+test('getFileBeforeUri - isolated provider', async () => {
+  const invocations: unknown[] = []
+  state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeSourceControlProvider': async (...args: readonly unknown[]) => {
+      invocations.push(args)
+      return { found: true, result: 'git-file-before://file:///workspace/file.txt' }
+    },
+  })
+
+  await expect(ExtensionHostSourceControl.getFileBeforeUri('git', 'file:///workspace/file.txt')).resolves.toBe(
+    'git-file-before://file:///workspace/file.txt',
+  )
+  expect(invocations).toEqual([['git', 'executeSourceControlGetFileBeforeUri', 'file:///workspace/file.txt']])
+})
+
 test('getGroups - isolated provider', async () => {
   const invocations: unknown[] = []
   state.extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({


### PR DESCRIPTION
Summary:
- add extension API support for registered read-only file system providers
- add source control before-file URIs with a legacy data URI fallback
- route isolated extension file reads through extension management