### PR TITLE
fix: verify view load error details

### DIFF
--- a/packages/e2e/src/sample.isolated-extension-view-virtual-dom-create-error.ts
+++ b/packages/e2e/src/sample.isolated-extension-view-virtual-dom-create-error.ts
@@ -9,6 +9,9 @@ export const test: Test = async ({ ActivityBar, expect, Extension, Locator }) =>
   await Extension.addWebExtension(uri)
   await ActivityBar.toggleActivityBarItem('sample.views.virtualDomCreateError')
 
-  const errorMessage = Locator('text=create failed')
-  await expect(errorMessage).toBeVisible()
+  const error = Locator('.Viewlet.Error')
+  await expect(error).toBeVisible()
+  await expect(error).toContainText('Error: create failed')
+  await expect(error).toContainText("throw new Error('create failed')")
+  await expect(error).toContainText('at create (')
 }


### PR DESCRIPTION
Strengthens the isolated extension view create-error regression to verify the visible message, source code frame, and stack trace.