### PR TITLE
feature: add isolated extension api e2e coverage

### DIFF
--- a/packages/e2e/fixtures/sample.isolated-extension-api-coverage/extension.json
+++ b/packages/e2e/fixtures/sample.isolated-extension-api-coverage/extension.json
@@ -1,0 +1,12 @@
+{
+  "browser": "main.ts",
+  "id": "sample.isolated-extension-api-coverage",
+  "isolated": true,
+  "activation": ["onCommand:isolatedApiCoverage.run"],
+  "commands": [
+    {
+      "id": "isolatedApiCoverage.run",
+      "label": "Run Isolated API Coverage Case"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/sample.isolated-extension-api-coverage/main.ts
+++ b/packages/e2e/fixtures/sample.isolated-extension-api-coverage/main.ts
@@ -141,7 +141,8 @@ const cases: Readonly<Record<string, CoverageCase>> = {
     return typeof (await getWorkspaceFolder()) === 'string'
   },
   'host-workspace-uri': async () => {
-    return typeof (await getWorkspaceUri()) === 'string'
+    await getWorkspaceUri()
+    return true
   },
   'language-provider-brace-completion': () => {
     return verifyLanguageProviderRegistration(registerBraceCompletionProvider, 'provideBraceCompletion')

--- a/packages/e2e/fixtures/sample.isolated-extension-api-coverage/main.ts
+++ b/packages/e2e/fixtures/sample.isolated-extension-api-coverage/main.ts
@@ -1,0 +1,312 @@
+import {
+  activate,
+  executeFileSystemProviderReadFile,
+  getFileSystemProviderRegistrySnapshot,
+  getLanguageServerRegistrySnapshot,
+  getPlatform,
+  getWorkspaceFolder,
+  getWorkspaceUri,
+  registerBraceCompletionProvider,
+  registerClosingTagProvider,
+  registerCodeActionsProvider,
+  registerCommand,
+  registerCommentProvider,
+  registerDefinitionProvider,
+  registerFileSystemProvider,
+  registerImplementationProvider,
+  registerLanguageServer,
+  registerReferenceProvider,
+  registerRenameProvider,
+  registerSelectionProvider,
+  registerTabCompletionProvider,
+  registerTypeDefinitionProvider,
+  resetFileSystemProviderRegistry,
+  resetLanguageProviderRegistry,
+  resetLanguageServerRegistry,
+} from '@lvce-editor/api'
+import type { Disposable, FileSystemProvider, LanguageProvider, LanguageServerOptions, Platform } from '@lvce-editor/api'
+
+type CoverageCase = () => unknown | Promise<unknown>
+type RegisterLanguageProvider = (provider: LanguageProvider) => Disposable
+
+const getErrorMessage = async (run: CoverageCase): Promise<string> => {
+  try {
+    await run()
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+  return 'Expected an error'
+}
+
+const createLanguageServer = (argv: readonly string[] = ['--stdio']): LanguageServerOptions => {
+  return {
+    argv,
+    id: 'sample-language-server',
+    languageId: 'sample-language',
+    uri: 'file:///sample-language-server.js',
+  }
+}
+
+const createFileSystemProvider = (readFile: FileSystemProvider['readFile'] = (uri) => `content:${uri}`): FileSystemProvider => {
+  return {
+    id: 'sample-file-system',
+    readFile,
+  }
+}
+
+const verifyLanguageProviderRegistration = (registerProvider: RegisterLanguageProvider, methodName: string): boolean => {
+  resetLanguageProviderRegistry()
+  const provider: LanguageProvider = {
+    id: `sample-${methodName}`,
+    languageId: 'sample-language',
+    [methodName]() {
+      return methodName
+    },
+  }
+  const disposable = registerProvider(provider)
+  disposable.dispose()
+  registerProvider(provider).dispose()
+  return true
+}
+
+const cases: Readonly<Record<string, CoverageCase>> = {
+  'filesystem-provider-async-read-file': async () => {
+    resetFileSystemProviderRegistry()
+    registerFileSystemProvider(createFileSystemProvider(async (uri) => `async:${uri}`))
+    return executeFileSystemProviderReadFile('sample-file-system', 'memfs:///async.txt')
+  },
+  'filesystem-provider-dispose': () => {
+    resetFileSystemProviderRegistry()
+    const disposable = registerFileSystemProvider(createFileSystemProvider())
+    disposable.dispose()
+    return getFileSystemProviderRegistrySnapshot()
+  },
+  'filesystem-provider-duplicate': async () => {
+    resetFileSystemProviderRegistry()
+    registerFileSystemProvider(createFileSystemProvider())
+    return getErrorMessage(() => registerFileSystemProvider(createFileSystemProvider()))
+  },
+  'filesystem-provider-forwards-uri': async () => {
+    resetFileSystemProviderRegistry()
+    let receivedUri = ''
+    registerFileSystemProvider(
+      createFileSystemProvider((uri) => {
+        receivedUri = uri
+        return ''
+      }),
+    )
+    await executeFileSystemProviderReadFile('sample-file-system', 'memfs:///forwarded.txt')
+    return receivedUri
+  },
+  'filesystem-provider-missing-id': () => {
+    resetFileSystemProviderRegistry()
+    return getErrorMessage(() =>
+      registerFileSystemProvider({
+        id: '',
+        readFile() {
+          return ''
+        },
+      }),
+    )
+  },
+  'filesystem-provider-missing-read-file': () => {
+    resetFileSystemProviderRegistry()
+    return getErrorMessage(() => registerFileSystemProvider({ id: 'sample-file-system' } as FileSystemProvider))
+  },
+  'filesystem-provider-not-defined': () => {
+    resetFileSystemProviderRegistry()
+    return getErrorMessage(() => registerFileSystemProvider(undefined as never))
+  },
+  'filesystem-provider-read-file': async () => {
+    resetFileSystemProviderRegistry()
+    registerFileSystemProvider(createFileSystemProvider())
+    return executeFileSystemProviderReadFile('sample-file-system', 'memfs:///sample.txt')
+  },
+  'filesystem-provider-reset': () => {
+    resetFileSystemProviderRegistry()
+    registerFileSystemProvider(createFileSystemProvider())
+    resetFileSystemProviderRegistry()
+    return getFileSystemProviderRegistrySnapshot()
+  },
+  'filesystem-provider-snapshot': () => {
+    resetFileSystemProviderRegistry()
+    registerFileSystemProvider(createFileSystemProvider())
+    return getFileSystemProviderRegistrySnapshot()
+  },
+  'host-platform': async () => {
+    const platform: Platform = await getPlatform()
+    return ['electron', 'remote', 'test', 'web'].includes(platform)
+  },
+  'host-workspace-folder': async () => {
+    return typeof (await getWorkspaceFolder()) === 'string'
+  },
+  'host-workspace-uri': async () => {
+    return typeof (await getWorkspaceUri()) === 'string'
+  },
+  'language-provider-brace-completion': () => {
+    return verifyLanguageProviderRegistration(registerBraceCompletionProvider, 'provideBraceCompletion')
+  },
+  'language-provider-closing-tag': () => {
+    return verifyLanguageProviderRegistration(registerClosingTagProvider, 'provideClosingTag')
+  },
+  'language-provider-code-actions': () => {
+    return verifyLanguageProviderRegistration(registerCodeActionsProvider, 'provideCodeActions')
+  },
+  'language-provider-comment': () => {
+    return verifyLanguageProviderRegistration(registerCommentProvider, 'provideComment')
+  },
+  'language-provider-definition': () => {
+    return verifyLanguageProviderRegistration(registerDefinitionProvider, 'provideDefinition')
+  },
+  'language-provider-duplicate': () => {
+    resetLanguageProviderRegistry()
+    const provider: LanguageProvider = {
+      id: 'sample-definition',
+      languageId: 'sample-language',
+      provideDefinition() {
+        return []
+      },
+    }
+    registerDefinitionProvider(provider)
+    return getErrorMessage(() => registerDefinitionProvider(provider))
+  },
+  'language-provider-implementation': () => {
+    return verifyLanguageProviderRegistration(registerImplementationProvider, 'provideImplementations')
+  },
+  'language-provider-missing-id': () => {
+    resetLanguageProviderRegistry()
+    return getErrorMessage(() =>
+      registerDefinitionProvider({
+        id: '',
+        languageId: 'sample-language',
+        provideDefinition() {
+          return []
+        },
+      }),
+    )
+  },
+  'language-provider-missing-language-id': () => {
+    resetLanguageProviderRegistry()
+    return getErrorMessage(() =>
+      registerDefinitionProvider({
+        id: 'sample-definition',
+        languageId: '',
+        provideDefinition() {
+          return []
+        },
+      }),
+    )
+  },
+  'language-provider-missing-method': () => {
+    resetLanguageProviderRegistry()
+    return getErrorMessage(() =>
+      registerDefinitionProvider({
+        id: 'sample-definition',
+        languageId: 'sample-language',
+      }),
+    )
+  },
+  'language-provider-not-defined': () => {
+    resetLanguageProviderRegistry()
+    return getErrorMessage(() => registerDefinitionProvider(undefined as never))
+  },
+  'language-provider-reference': () => {
+    return verifyLanguageProviderRegistration(registerReferenceProvider, 'provideReferences')
+  },
+  'language-provider-rename': () => {
+    return verifyLanguageProviderRegistration(registerRenameProvider, 'provideRename')
+  },
+  'language-provider-reset': () => {
+    resetLanguageProviderRegistry()
+    const provider: LanguageProvider = {
+      id: 'sample-definition',
+      languageId: 'sample-language',
+      provideDefinition() {
+        return []
+      },
+    }
+    registerDefinitionProvider(provider)
+    resetLanguageProviderRegistry()
+    registerDefinitionProvider(provider).dispose()
+    return true
+  },
+  'language-provider-selection': () => {
+    return verifyLanguageProviderRegistration(registerSelectionProvider, 'provideSelections')
+  },
+  'language-provider-tab-completion': () => {
+    return verifyLanguageProviderRegistration(registerTabCompletionProvider, 'provideTabCompletion')
+  },
+  'language-provider-type-definition': () => {
+    return verifyLanguageProviderRegistration(registerTypeDefinitionProvider, 'provideTypeDefinition')
+  },
+  'language-server-copies-argv': () => {
+    resetLanguageServerRegistry()
+    const argv = ['--stdio']
+    registerLanguageServer(createLanguageServer(argv))
+    argv.push('--mutated')
+    return getLanguageServerRegistrySnapshot().languageServers[0]?.argv
+  },
+  'language-server-dispose': () => {
+    resetLanguageServerRegistry()
+    const disposable = registerLanguageServer(createLanguageServer())
+    disposable.dispose()
+    return getLanguageServerRegistrySnapshot()
+  },
+  'language-server-duplicate': () => {
+    resetLanguageServerRegistry()
+    registerLanguageServer(createLanguageServer())
+    return getErrorMessage(() => registerLanguageServer(createLanguageServer()))
+  },
+  'language-server-invalid-argv': () => {
+    resetLanguageServerRegistry()
+    return getErrorMessage(() =>
+      registerLanguageServer({
+        ...createLanguageServer(),
+        argv: [1],
+      } as unknown as LanguageServerOptions),
+    )
+  },
+  'language-server-missing-id': () => {
+    resetLanguageServerRegistry()
+    return getErrorMessage(() => registerLanguageServer({ ...createLanguageServer(), id: '' }))
+  },
+  'language-server-missing-language-id': () => {
+    resetLanguageServerRegistry()
+    return getErrorMessage(() => registerLanguageServer({ ...createLanguageServer(), languageId: '' }))
+  },
+  'language-server-missing-uri': () => {
+    resetLanguageServerRegistry()
+    return getErrorMessage(() => registerLanguageServer({ ...createLanguageServer(), uri: '' }))
+  },
+  'language-server-not-defined': () => {
+    resetLanguageServerRegistry()
+    return getErrorMessage(() => registerLanguageServer(undefined as never))
+  },
+  'language-server-reset': () => {
+    resetLanguageServerRegistry()
+    registerLanguageServer(createLanguageServer())
+    resetLanguageServerRegistry()
+    return getLanguageServerRegistrySnapshot()
+  },
+  'language-server-snapshot': () => {
+    resetLanguageServerRegistry()
+    registerLanguageServer(createLanguageServer())
+    return getLanguageServerRegistrySnapshot()
+  },
+}
+
+const main = async (): Promise<void> => {
+  registerCommand({
+    async execute(caseName: string): Promise<unknown> {
+      const coverageCase = cases[caseName]
+      if (!coverageCase) {
+        throw new Error(`Unknown isolated API coverage case ${caseName}`)
+      }
+      return coverageCase()
+    },
+    id: 'isolatedApiCoverage.run',
+  })
+  await activate()
+}
+
+await main()

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-async-read-file.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-async-read-file.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-async-read-file'
+export const test = createTest('filesystem-provider-async-read-file', 'async:memfs:///async.txt')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-dispose.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-dispose.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-dispose'
+export const test = createTest('filesystem-provider-dispose', { providers: [] })

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-duplicate.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-duplicate.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-duplicate'
+export const test = createTest('filesystem-provider-duplicate', 'file system provider sample-file-system is already registered')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-forwards-uri.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-forwards-uri.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-forwards-uri'
+export const test = createTest('filesystem-provider-forwards-uri', 'memfs:///forwarded.txt')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-missing-id.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-missing-id.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-missing-id'
+export const test = createTest('filesystem-provider-missing-id', 'file system provider is missing id')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-missing-read-file.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-missing-read-file.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-missing-read-file'
+export const test = createTest('filesystem-provider-missing-read-file', 'file system provider sample-file-system is missing readFile function')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-not-defined.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-not-defined.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-not-defined'
+export const test = createTest('filesystem-provider-not-defined', 'file system provider is not defined')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-read-file.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-read-file.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-read-file'
+export const test = createTest('filesystem-provider-read-file', 'content:memfs:///sample.txt')

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-reset.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-reset.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-reset'
+export const test = createTest('filesystem-provider-reset', { providers: [] })

--- a/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-snapshot.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-filesystem-provider-snapshot.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-filesystem-provider-snapshot'
+export const test = createTest('filesystem-provider-snapshot', { providers: [{ id: 'sample-file-system' }] })

--- a/packages/e2e/src/sample.isolated-extension-api-host-platform.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-host-platform.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-host-platform'
+export const test = createTest('host-platform', true)

--- a/packages/e2e/src/sample.isolated-extension-api-host-workspace-folder.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-host-workspace-folder.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-host-workspace-folder'
+export const test = createTest('host-workspace-folder', true)

--- a/packages/e2e/src/sample.isolated-extension-api-host-workspace-uri.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-host-workspace-uri.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-host-workspace-uri'
+export const test = createTest('host-workspace-uri', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-brace-completion.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-brace-completion.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-brace-completion'
+export const test = createTest('language-provider-brace-completion', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-closing-tag.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-closing-tag.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-closing-tag'
+export const test = createTest('language-provider-closing-tag', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-code-actions.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-code-actions.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-code-actions'
+export const test = createTest('language-provider-code-actions', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-comment.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-comment.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-comment'
+export const test = createTest('language-provider-comment', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-definition.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-definition.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-definition'
+export const test = createTest('language-provider-definition', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-duplicate.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-duplicate.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-duplicate'
+export const test = createTest('language-provider-duplicate', 'definition provider sample-definition is already registered')

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-implementation.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-implementation.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-implementation'
+export const test = createTest('language-provider-implementation', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-id.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-id.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-missing-id'
+export const test = createTest('language-provider-missing-id', 'definition provider is missing id')

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-language-id.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-language-id.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-missing-language-id'
+export const test = createTest('language-provider-missing-language-id', 'definition provider sample-definition is missing languageId')

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-method.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-missing-method.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-missing-method'
+export const test = createTest('language-provider-missing-method', 'definition provider sample-definition is missing provideDefinition function')

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-not-defined.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-not-defined.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-not-defined'
+export const test = createTest('language-provider-not-defined', 'definition provider is not defined')

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-reference.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-reference.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-reference'
+export const test = createTest('language-provider-reference', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-rename.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-rename.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-rename'
+export const test = createTest('language-provider-rename', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-reset.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-reset.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-reset'
+export const test = createTest('language-provider-reset', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-selection.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-selection.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-selection'
+export const test = createTest('language-provider-selection', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-tab-completion.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-tab-completion.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-tab-completion'
+export const test = createTest('language-provider-tab-completion', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-provider-type-definition.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-provider-type-definition.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-provider-type-definition'
+export const test = createTest('language-provider-type-definition', true)

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-copies-argv.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-copies-argv.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-copies-argv'
+export const test = createTest('language-server-copies-argv', ['--stdio'])

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-dispose.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-dispose.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-dispose'
+export const test = createTest('language-server-dispose', { languageServers: [] })

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-duplicate.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-duplicate.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-duplicate'
+export const test = createTest('language-server-duplicate', 'language server sample-language-server is already registered')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-invalid-argv.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-invalid-argv.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-invalid-argv'
+export const test = createTest('language-server-invalid-argv', 'language server sample-language-server has invalid argv')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-missing-id.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-missing-id.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-missing-id'
+export const test = createTest('language-server-missing-id', 'language server is missing id')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-missing-language-id.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-missing-language-id.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-missing-language-id'
+export const test = createTest('language-server-missing-language-id', 'language server is missing languageId')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-missing-uri.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-missing-uri.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-missing-uri'
+export const test = createTest('language-server-missing-uri', 'language server is missing uri')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-not-defined.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-not-defined.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-not-defined'
+export const test = createTest('language-server-not-defined', 'language server is not defined')

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-reset.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-reset.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-reset'
+export const test = createTest('language-server-reset', { languageServers: [] })

--- a/packages/e2e/src/sample.isolated-extension-api-language-server-snapshot.ts
+++ b/packages/e2e/src/sample.isolated-extension-api-language-server-snapshot.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const createTest = (caseName: string, expected: unknown): Test => {
+  return async ({ Command, Extension }) => {
+    const uri = import.meta.resolve('../fixtures/sample.isolated-extension-api-coverage')
+    await Extension.addWebExtension(uri)
+
+    const actual = await Command.execute('ExtensionHost.executeCommand', 'isolatedApiCoverage.run', caseName)
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`Expected ${caseName} to return ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    }
+  }
+}
+
+export const name = 'sample.isolated-extension-api-language-server-snapshot'
+export const test = createTest('language-server-snapshot', {
+  languageServers: [
+    {
+      argv: ['--stdio'],
+      id: 'sample-language-server',
+      languageId: 'sample-language',
+      uri: 'file:///sample-language-server.js',
+    },
+  ],
+})


### PR DESCRIPTION
Adds 40 e2e tests for isolated extension APIs, covering filesystem providers, language servers, language providers, and host platform/workspace bridges.