### PR TITLE
feature: accept custom quick pick input

### DIFF
--- a/packages/extension-api/src/parts/ShowQuickPickOptions/ShowQuickPickOptions.ts
+++ b/packages/extension-api/src/parts/ShowQuickPickOptions/ShowQuickPickOptions.ts
@@ -1,6 +1,7 @@
 import type { QuickPickItem } from '../QuickPickItem/QuickPickItem.ts'
 
 export interface ShowQuickPickOptions {
+  readonly acceptInput?: boolean
   readonly items: readonly QuickPickItem[]
   readonly placeholder?: string
 }

--- a/packages/extension-api/test/parts/QuickPick/QuickPick.test.ts
+++ b/packages/extension-api/test/parts/QuickPick/QuickPick.test.ts
@@ -23,6 +23,7 @@ test('showQuickPick invokes extension host quick pick command', async () => {
     },
   })
   const options = {
+    acceptInput: true,
     items: [
       {
         description: 'First option',

--- a/packages/extension-host-worker/src/parts/ExtensionHostQuickPick/ExtensionHostQuickPick.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostQuickPick/ExtensionHostQuickPick.ts
@@ -7,6 +7,7 @@ export interface QuickPickItem {
 }
 
 export interface ShowQuickPickOptions {
+  readonly acceptInput?: boolean
   readonly items: readonly QuickPickItem[]
   readonly placeholder?: string
 }
@@ -26,7 +27,7 @@ const validateQuickPickItem = (item: QuickPickItem): void => {
   }
 }
 
-export const showQuickPick = async ({ items, placeholder }: ShowQuickPickOptions): Promise<unknown> => {
+export const showQuickPick = async ({ acceptInput = false, items, placeholder }: ShowQuickPickOptions): Promise<unknown> => {
   if (!Array.isArray(items)) {
     throw new TypeError('showQuickPick items must be an array')
   }
@@ -34,6 +35,7 @@ export const showQuickPick = async ({ items, placeholder }: ShowQuickPickOptions
     validateQuickPickItem(item)
   }
   return QuickPickWorker.invoke('QuickPick.showQuickPick', {
+    acceptInput,
     items,
     placeholder,
   })

--- a/packages/extension-host-worker/test/ExtensionHostQuickPick.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostQuickPick.test.ts
@@ -33,6 +33,7 @@ test('showQuickPick', async () => {
   ]
 
   const result = await ExtensionHostQuickPick.showQuickPick({
+    acceptInput: true,
     items,
     placeholder: 'Select branch',
   })
@@ -40,6 +41,7 @@ test('showQuickPick', async () => {
   expect(result).toBe('branch-2')
   expect(quickPickInvoke).toHaveBeenCalledTimes(1)
   expect(quickPickInvoke).toHaveBeenCalledWith('QuickPick.showQuickPick', {
+    acceptInput: true,
     items,
     placeholder: 'Select branch',
   })
@@ -59,6 +61,17 @@ test('showQuickPick - canceled', async () => {
   })
 
   expect(result).toBeUndefined()
+  expect(quickPickInvoke).toHaveBeenCalledWith('QuickPick.showQuickPick', {
+    acceptInput: false,
+    items: [
+      {
+        description: 'Local branch',
+        label: 'branch 1',
+        value: 'branch-1',
+      },
+    ],
+    placeholder: undefined,
+  })
 })
 
 test('showQuickPick - missing description', async () => {


### PR DESCRIPTION
Adds an opt-in `acceptInput` quick-pick API option and forwards it to the quick-pick worker so extensions can submit typed values.