### PR TITLE
feature: add spinning status bar item property

### DIFF
--- a/packages/extension-api/src/parts/StatusBarItem/StatusBarItem.ts
+++ b/packages/extension-api/src/parts/StatusBarItem/StatusBarItem.ts
@@ -2,6 +2,7 @@ export interface StatusBarItem {
   readonly icon?: string
   readonly name?: string
   readonly onClick?: string
+  readonly spinning?: boolean
   readonly text?: string
   readonly title?: string
 }

--- a/packages/extension-api/test/parts/StatusBarItemProviderRegistry/StatusBarItemProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/StatusBarItemProviderRegistry/StatusBarItemProviderRegistry.test.ts
@@ -35,6 +35,7 @@ test('registerStatusBarItemProvider registers and returns items', () => {
     getStatusBarItem() {
       return {
         name: 'sample.status',
+        spinning: true,
         text: 'Ready',
       }
     },
@@ -42,6 +43,7 @@ test('registerStatusBarItemProvider registers and returns items', () => {
   })
 
   strictEqual(getStatusBarItemProviderRegistrySnapshot().providers.length, 1)
+  strictEqual(getStatusBarItems()[0]?.spinning, true)
   strictEqual(getStatusBarItems()[0]?.text, 'Ready')
 
   handle.dispose()


### PR DESCRIPTION
Adds an optional spinning flag to extension status bar items so extensions can expose in-progress icon state.