### PR TITLE
feature: use dialog worker directly

### DIFF
--- a/packages/extension-host-worker/package-lock.json
+++ b/packages/extension-host-worker/package-lock.json
@@ -15,7 +15,7 @@
         "@jest/globals": "^30.4.1",
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/rpc": "^6.4.0",
-        "@lvce-editor/rpc-registry": "^9.27.0",
+        "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/verror": "^1.7.0",
         "@types/node": "^25.0.6",
         "idb": "^8.0.3",
@@ -1005,9 +1005,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.14.0.tgz",
-      "integrity": "sha512-eJvcdatVxKHYVtVhMOIULPo53uMNl6YCNztj65ejI4zVrP0qUspM2ymhpglyRoDnyZ+XtUVlMduCmSSq0fT6eQ==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/ipc": {
@@ -1046,14 +1046,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.27.0.tgz",
-      "integrity": "sha512-rMqWoslwQb1H55QTwCgSbFVdc68YqQpK78ZjXmPxs+iQ9RFe+7qVl6mvfyiuFiRNe9avvln42vbt9WhaqWJiug==",
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.14.0",
+        "@lvce-editor/constants": "^5.22.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },

--- a/packages/extension-host-worker/package.json
+++ b/packages/extension-host-worker/package.json
@@ -52,7 +52,7 @@
     "@jest/globals": "^30.4.1",
     "@lvce-editor/assert": "^1.5.1",
     "@lvce-editor/rpc": "^6.4.0",
-    "@lvce-editor/rpc-registry": "^9.27.0",
+    "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/verror": "^1.7.0",
     "@types/node": "^25.0.6",
     "idb": "^8.0.3",

--- a/packages/extension-host-worker/src/parts/ExtensionHostPrompt/ExtensionHostPrompt.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostPrompt/ExtensionHostPrompt.ts
@@ -1,8 +1,8 @@
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 import * as Assert from '../Assert/Assert.ts'
-import * as Rpc from '../Rpc/Rpc.ts'
 
 export const confirm = (message) => {
   Assert.string(message)
-  const result = Rpc.invoke('ConfirmPrompt.prompt', message)
+  const result = DialogWorker.invoke('ConfirmPrompt.prompt', message)
   return result
 }

--- a/packages/extension-host-worker/src/parts/Listen/Listen.ts
+++ b/packages/extension-host-worker/src/parts/Listen/Listen.ts
@@ -1,3 +1,5 @@
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import { launchExtensionManagementWorker } from '../LaunchExtensionManagementWorker/LaunchExtensionManagementWorker.ts'
 import { launchFileSearchWorker } from '../LaunchFileSearchWorker/LaunchFileSearchWorker.ts'
 import { launchQuickPickWorker } from '../LaunchQuickPickWorker/LaunchQuickPickWorker.ts'
@@ -5,4 +7,9 @@ import { launchRendererWorker } from '../LaunchRendererWorker/LaunchRendererWork
 
 export const listen = async (): Promise<void> => {
   await Promise.all([launchExtensionManagementWorker(), launchFileSearchWorker(), launchRendererWorker(), launchQuickPickWorker()])
+  const dialogRpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: RendererWorker.sendMessagePortToDialogWorker,
+  })
+  DialogWorker.set(dialogRpc)
 }

--- a/packages/extension-host-worker/test/ExtensionHostPrompt.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostPrompt.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const dialogWorkerInvoke = jest.fn()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('@lvce-editor/rpc-registry', () => {
+  return {
+    DialogWorker: {
+      invoke: dialogWorkerInvoke,
+    },
+  }
+})
+
+const ExtensionHostPrompt = await import('../src/parts/ExtensionHostPrompt/ExtensionHostPrompt.ts')
+
+test('confirms through dialog worker', async () => {
+  dialogWorkerInvoke.mockResolvedValueOnce(true as never)
+
+  await expect(ExtensionHostPrompt.confirm('Continue?')).resolves.toBe(true)
+
+  expect(dialogWorkerInvoke).toHaveBeenCalledWith('ConfirmPrompt.prompt', 'Continue?')
+})


### PR DESCRIPTION
## Summary

- connect to dialog-worker through a lazy transferred message port
- send confirm and message-box requests directly to dialog-worker
- update rpc-registry and the affected tests

## Testing

- focused dialog and Listen tests
- npm run type-check
- npm run lint