### PR TITLE
feature: support isolated file system providers

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -26,6 +26,9 @@ export {
 } from './parts/Formatting/Formatting.ts'
 export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
 export {
+  executeFileSystemProviderGetPathSeparator,
+  executeFileSystemProviderIsReadonly,
+  executeFileSystemProviderReadDirWithFileTypes,
   executeFileSystemProviderReadFile,
   getFileSystemProviderRegistrySnapshot,
   registerFileSystemProvider,

--- a/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
+++ b/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
@@ -1,7 +1,13 @@
 import { executeCommand, getCommandRegistrySnapshot } from '../CommandRegistry/CommandRegistry.ts'
 import { executeCompletionProvider, executeResolveCompletionItemProvider, getCompletionProviderRegistrySnapshot } from '../Completion/Completion.ts'
 import { executeDiagnosticProvider, getDiagnosticProviderRegistrySnapshot } from '../Diagnostic/Diagnostic.ts'
-import { executeFileSystemProviderReadFile, getFileSystemProviderRegistrySnapshot } from '../FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
+import {
+  executeFileSystemProviderGetPathSeparator,
+  executeFileSystemProviderIsReadonly,
+  executeFileSystemProviderReadDirWithFileTypes,
+  executeFileSystemProviderReadFile,
+  getFileSystemProviderRegistrySnapshot,
+} from '../FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
 import { executeFormattingProvider, getFormattingProviderRegistrySnapshot } from '../Formatting/Formatting.ts'
 import { getStatusBarItems } from '../GetStatusBarItems/GetStatusBarItems.ts'
 import { executeHoverProvider, getHoverProviderRegistrySnapshot } from '../Hover/Hover.ts'
@@ -43,6 +49,9 @@ export const commandMap = {
   'ExtensionApi.executeCommand': executeCommand,
   'ExtensionApi.executeCompletionProvider': executeCompletionProvider,
   'ExtensionApi.executeDiagnosticProvider': executeDiagnosticProvider,
+  'ExtensionApi.executeFileSystemProviderGetPathSeparator': executeFileSystemProviderGetPathSeparator,
+  'ExtensionApi.executeFileSystemProviderIsReadonly': executeFileSystemProviderIsReadonly,
+  'ExtensionApi.executeFileSystemProviderReadDirWithFileTypes': executeFileSystemProviderReadDirWithFileTypes,
   'ExtensionApi.executeFileSystemProviderReadFile': executeFileSystemProviderReadFile,
   'ExtensionApi.executeFormattingProvider': executeFormattingProvider,
   'ExtensionApi.executeHoverProvider': executeHoverProvider,

--- a/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
+++ b/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
@@ -1,4 +1,9 @@
+import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
+
 export interface FileSystemProvider {
   readonly id: string
+  readonly isReadonly?: () => boolean | Promise<boolean>
+  readonly pathSeparator?: string
+  readonly readDirWithFileTypes?: (uri: string) => readonly FileSystemDirent[] | Promise<readonly FileSystemDirent[]>
   readonly readFile: (uri: string) => string | Promise<string>
 }

--- a/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
@@ -1,4 +1,5 @@
 import type { Disposable } from '../Disposable/Disposable.ts'
+import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
 import type { FileSystemProvider } from '../FileSystemProvider/FileSystemProvider.ts'
 import type { FileSystemProviderRegistrySnapshot } from '../FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts'
 import type { RegisteredFileSystemProvider } from '../RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts'
@@ -15,6 +16,15 @@ const assertFileSystemProvider = (provider: FileSystemProvider): void => {
   }
   if (typeof provider.readFile !== 'function') {
     throw new ExtensionApiError(`file system provider ${provider.id} is missing readFile function`)
+  }
+  if (provider.readDirWithFileTypes !== undefined && typeof provider.readDirWithFileTypes !== 'function') {
+    throw new ExtensionApiError(`file system provider ${provider.id} has invalid readDirWithFileTypes function`)
+  }
+  if (provider.isReadonly !== undefined && typeof provider.isReadonly !== 'function') {
+    throw new ExtensionApiError(`file system provider ${provider.id} has invalid isReadonly function`)
+  }
+  if (provider.pathSeparator !== undefined && typeof provider.pathSeparator !== 'string') {
+    throw new ExtensionApiError(`file system provider ${provider.id} has invalid pathSeparator`)
   }
   if (provider.id in providers) {
     throw new ExtensionApiError(`file system provider ${provider.id} is already registered`)
@@ -33,6 +43,23 @@ export const executeFileSystemProviderReadFile = async (id: string, uri: string)
   return getProvider(id).readFile(uri)
 }
 
+export const executeFileSystemProviderReadDirWithFileTypes = async (id: string, uri: string): Promise<readonly FileSystemDirent[]> => {
+  const provider = getProvider(id)
+  if (!provider.readDirWithFileTypes) {
+    throw new ExtensionApiError(`file system provider ${id} is missing readDirWithFileTypes function`)
+  }
+  return provider.readDirWithFileTypes(uri)
+}
+
+export const executeFileSystemProviderGetPathSeparator = (id: string): string => {
+  return getProvider(id).pathSeparator || '/'
+}
+
+export const executeFileSystemProviderIsReadonly = async (id: string): Promise<boolean> => {
+  const provider = getProvider(id)
+  return provider.isReadonly ? provider.isReadonly() : false
+}
+
 export const getFileSystemProviderRegistrySnapshot = (): FileSystemProviderRegistrySnapshot => {
   return {
     providers: Object.values(providers).map((provider) => ({
@@ -45,6 +72,9 @@ export const registerFileSystemProvider = (provider: FileSystemProvider): Dispos
   assertFileSystemProvider(provider)
   providers[provider.id] = {
     id: provider.id,
+    isReadonly: provider.isReadonly,
+    pathSeparator: provider.pathSeparator,
+    readDirWithFileTypes: provider.readDirWithFileTypes,
     readFile: (uri) => provider.readFile(uri),
   }
   return {

--- a/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
+++ b/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
@@ -1,4 +1,9 @@
+import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
+
 export interface RegisteredFileSystemProvider {
   readonly id: string
+  readonly isReadonly?: () => boolean | Promise<boolean>
+  readonly pathSeparator?: string
+  readonly readDirWithFileTypes?: (uri: string) => readonly FileSystemDirent[] | Promise<readonly FileSystemDirent[]>
   readonly readFile: (uri: string) => string | Promise<string>
 }

--- a/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
+++ b/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
@@ -29,6 +29,9 @@ test('commandMap keeps completion, diagnostic and formatting provider commands',
 })
 
 test('commandMap exposes file system provider commands', () => {
+  strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderGetPathSeparator'], 'function')
+  strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderIsReadonly'], 'function')
+  strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderReadDirWithFileTypes'], 'function')
   strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderReadFile'], 'function')
   strictEqual(typeof commandMap['ExtensionApi.getFileSystemProviderRegistrySnapshot'], 'function')
 })

--- a/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
@@ -1,6 +1,9 @@
 import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import {
+  executeFileSystemProviderGetPathSeparator,
+  executeFileSystemProviderIsReadonly,
+  executeFileSystemProviderReadDirWithFileTypes,
   executeFileSystemProviderReadFile,
   getFileSystemProviderRegistrySnapshot,
   registerFileSystemProvider,
@@ -11,9 +14,16 @@ afterEach(() => {
   resetFileSystemProviderRegistry()
 })
 
-test('registerFileSystemProvider registers and reads files', async () => {
+test('registerFileSystemProvider registers and executes provider operations', async () => {
   const disposable = registerFileSystemProvider({
     id: 'git-file-before',
+    isReadonly() {
+      return true
+    },
+    pathSeparator: '/',
+    readDirWithFileTypes(uri) {
+      return [{ name: uri, type: 1 }]
+    },
     readFile(uri) {
       return `before:${uri}`
     },
@@ -23,6 +33,11 @@ test('registerFileSystemProvider registers and reads files', async () => {
     providers: [{ id: 'git-file-before' }],
   })
   strictEqual(await executeFileSystemProviderReadFile('git-file-before', 'file:///workspace/file.txt'), 'before:file:///workspace/file.txt')
+  deepStrictEqual(await executeFileSystemProviderReadDirWithFileTypes('git-file-before', 'file:///workspace'), [
+    { name: 'file:///workspace', type: 1 },
+  ])
+  strictEqual(executeFileSystemProviderGetPathSeparator('git-file-before'), '/')
+  strictEqual(await executeFileSystemProviderIsReadonly('git-file-before'), true)
 
   disposable.dispose()
   deepStrictEqual(getFileSystemProviderRegistrySnapshot(), { providers: [] })
@@ -40,4 +55,30 @@ test('registerFileSystemProvider rejects a missing readFile function', () => {
 
 test('executeFileSystemProviderReadFile rejects an unknown provider', async () => {
   await rejects(executeFileSystemProviderReadFile('missing', 'file:///workspace/file.txt'), /file system provider missing not found/)
+})
+
+test('optional provider metadata uses writable posix defaults', async () => {
+  registerFileSystemProvider({
+    id: 'minimal',
+    readFile() {
+      return ''
+    },
+  })
+
+  strictEqual(executeFileSystemProviderGetPathSeparator('minimal'), '/')
+  strictEqual(await executeFileSystemProviderIsReadonly('minimal'), false)
+  await rejects(executeFileSystemProviderReadDirWithFileTypes('minimal', 'file:///workspace'), /missing readDirWithFileTypes function/)
+})
+
+test('registerFileSystemProvider rejects invalid optional operations', () => {
+  throws(() => {
+    registerFileSystemProvider({
+      id: 'invalid',
+      // @ts-expect-error testing invalid provider shape
+      isReadonly: true,
+      readFile() {
+        return ''
+      },
+    })
+  }, /file system provider invalid has invalid isReadonly function/)
 })

--- a/packages/extension-host-worker/src/parts/ExecuteIsolatedFileSystemProvider/ExecuteIsolatedFileSystemProvider.ts
+++ b/packages/extension-host-worker/src/parts/ExecuteIsolatedFileSystemProvider/ExecuteIsolatedFileSystemProvider.ts
@@ -12,13 +12,29 @@ const isUnavailableError = (error: unknown): boolean => {
   )
 }
 
-export const execute = async (providerId: string, uri: string): Promise<FileSystemProviderResult> => {
+const executeMethod = async (method: string, providerId: string, ...args: readonly unknown[]): Promise<FileSystemProviderResult> => {
   try {
-    return await ExtensionManagementWorker.invoke('Extensions.executeFileSystemProviderReadFile', providerId, uri)
+    return await ExtensionManagementWorker.invoke(method, providerId, ...args)
   } catch (error) {
     if (isUnavailableError(error)) {
       return { found: false }
     }
     throw error
   }
+}
+
+export const execute = (providerId: string, uri: string): Promise<FileSystemProviderResult> => {
+  return executeMethod('Extensions.executeFileSystemProviderReadFile', providerId, uri)
+}
+
+export const getPathSeparator = (providerId: string): Promise<FileSystemProviderResult> => {
+  return executeMethod('Extensions.executeFileSystemProviderGetPathSeparator', providerId)
+}
+
+export const isReadonly = (providerId: string): Promise<FileSystemProviderResult> => {
+  return executeMethod('Extensions.executeFileSystemProviderIsReadonly', providerId)
+}
+
+export const readDirWithFileTypes = (providerId: string, uri: string): Promise<FileSystemProviderResult> => {
+  return executeMethod('Extensions.executeFileSystemProviderReadDirWithFileTypes', providerId, uri)
 }

--- a/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostFileSystem/ExtensionHostFileSystem.ts
@@ -12,8 +12,15 @@ export const registerFileSystemProvider = (fileSystemProvider) => {
 
 export const readDirWithFileTypes = async (protocol, path) => {
   try {
-    const provider = FileSystemProviderState.get(protocol)
-    return await provider.readDirWithFileTypes(path)
+    const provider = FileSystemProviderState.getOptional(protocol)
+    if (provider) {
+      return await provider.readDirWithFileTypes(path)
+    }
+    const isolated = await ExecuteIsolatedFileSystemProvider.readDirWithFileTypes(protocol, path)
+    if (isolated.found) {
+      return isolated.result
+    }
+    return await FileSystemProviderState.get(protocol).readDirWithFileTypes(path)
   } catch (error) {
     throw new VError(error, 'Failed to execute file system provider')
   }
@@ -123,10 +130,17 @@ export const exists = async (protocol, uri) => {
   }
 }
 
-export const getPathSeparator = (protocol) => {
+export const getPathSeparator = async (protocol) => {
   try {
-    const provider = FileSystemProviderState.get(protocol)
-    return provider.pathSeparator
+    const provider = FileSystemProviderState.getOptional(protocol)
+    if (provider) {
+      return provider.pathSeparator
+    }
+    const isolated = await ExecuteIsolatedFileSystemProvider.getPathSeparator(protocol)
+    if (isolated.found) {
+      return isolated.result
+    }
+    return FileSystemProviderState.get(protocol).pathSeparator
   } catch (error) {
     throw new VError(error, 'Failed to execute file system provider')
   }
@@ -134,11 +148,18 @@ export const getPathSeparator = (protocol) => {
 
 export const isReadonly = async (protocol) => {
   try {
-    const provider = FileSystemProviderState.get(protocol)
-    if (!provider.isReadonly) {
-      return false
+    const provider = FileSystemProviderState.getOptional(protocol)
+    if (provider) {
+      if (!provider.isReadonly) {
+        return false
+      }
+      return await provider.isReadonly()
     }
-    return await provider.isReadonly()
+    const isolated = await ExecuteIsolatedFileSystemProvider.isReadonly(protocol)
+    if (isolated.found) {
+      return isolated.result
+    }
+    return await FileSystemProviderState.get(protocol).isReadonly()
   } catch (error) {
     throw new VError(error, 'Failed to execute file system provider')
   }

--- a/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostFileSystem.test.ts
@@ -58,6 +58,22 @@ test('readDirWithFileTypes', async () => {
   ])
 })
 
+test('readDirWithFileTypes - isolated provider', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeFileSystemProviderReadDirWithFileTypes': async (providerId: string, uri: string) => {
+      return {
+        found: true,
+        result: [{ name: `${providerId}:${uri}`, type: 'file' }],
+      }
+    },
+  })
+
+  await expect(ExtensionHostFileSystem.readDirWithFileTypes('fetch', 'fetch:///workspace')).resolves.toEqual([
+    { name: 'fetch:fetch:///workspace', type: 'file' },
+  ])
+  expect(mockRpc.invocations).toEqual([['Extensions.executeFileSystemProviderReadDirWithFileTypes', 'fetch', 'fetch:///workspace']])
+})
+
 test('readDirWithFileTypes - when file system provider throws error', async () => {
   ExtensionHostFileSystem.registerFileSystemProvider({
     id: 'memfs',
@@ -142,7 +158,7 @@ test('rename - when file system provider is not registered', async () => {
   )
 })
 
-test('getPathSeparator - slash', () => {
+test('getPathSeparator - slash', async () => {
   ExtensionHostFileSystem.registerFileSystemProvider({
     id: 'memfs',
     pathSeparator: '/',
@@ -155,10 +171,10 @@ test('getPathSeparator - slash', () => {
       ]
     },
   })
-  expect(ExtensionHostFileSystem.getPathSeparator('memfs')).toBe('/')
+  await expect(ExtensionHostFileSystem.getPathSeparator('memfs')).resolves.toBe('/')
 })
 
-test('getPathSeparator - backslash', () => {
+test('getPathSeparator - backslash', async () => {
   ExtensionHostFileSystem.registerFileSystemProvider({
     id: 'memfs',
     pathSeparator: '\\',
@@ -171,7 +187,21 @@ test('getPathSeparator - backslash', () => {
       ]
     },
   })
-  expect(ExtensionHostFileSystem.getPathSeparator('memfs')).toBe('\\')
+  await expect(ExtensionHostFileSystem.getPathSeparator('memfs')).resolves.toBe('\\')
+})
+
+test('getPathSeparator - isolated provider', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeFileSystemProviderGetPathSeparator': async () => {
+      return {
+        found: true,
+        result: '/',
+      }
+    },
+  })
+
+  await expect(ExtensionHostFileSystem.getPathSeparator('fetch')).resolves.toBe('/')
+  expect(mockRpc.invocations).toEqual([['Extensions.executeFileSystemProviderGetPathSeparator', 'fetch']])
 })
 
 test('isReadonly - default false', async () => {
@@ -189,6 +219,20 @@ test('isReadonly', async () => {
     },
   })
   await expect(ExtensionHostFileSystem.isReadonly('memfs')).resolves.toBe(true)
+})
+
+test('isReadonly - isolated provider', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.executeFileSystemProviderIsReadonly': async () => {
+      return {
+        found: true,
+        result: true,
+      }
+    },
+  })
+
+  await expect(ExtensionHostFileSystem.isReadonly('fetch')).resolves.toBe(true)
+  expect(mockRpc.invocations).toEqual([['Extensions.executeFileSystemProviderIsReadonly', 'fetch']])
 })
 
 test('isReadonly - when file system provider throws error', async () => {


### PR DESCRIPTION
Adds isolated file-system provider support for directory listings, path separators, and read-only status in the extension API and legacy filesystem bridge.

This preserves the full read-side contract needed to migrate the file-system-fetch extension away from the global vscode API.