### PR TITLE
feature: add extension notification api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -34,7 +34,15 @@ export {
   registerFileSystemProvider,
   resetFileSystemProviderRegistry,
 } from './parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
-export { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from './parts/Host/Host.ts'
+export {
+  confirm,
+  getWorkspaceFolder,
+  getWorkspaceUri,
+  handleWorkspaceRefresh,
+  openUri,
+  showNotification,
+  type NotificationType,
+} from './parts/Host/Host.ts'
 export { executeHoverProvider, getHoverProviderRegistrySnapshot, registerHoverProvider, resetHoverProviderRegistry } from './parts/Hover/Hover.ts'
 export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
 export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -1,5 +1,7 @@
 import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
 
+export type NotificationType = 'error' | 'info' | 'warning'
+
 export const confirm = async (message: string): Promise<boolean> => {
   return Boolean(await executeCommand('ConfirmPrompt.prompt', message))
 }
@@ -18,4 +20,8 @@ export const handleWorkspaceRefresh = async (): Promise<void> => {
 
 export const openUri = async (uri: string): Promise<void> => {
   await executeCommand('Main.openUri', uri)
+}
+
+export const showNotification = async (type: NotificationType, message: string): Promise<void> => {
+  await executeCommand('Notification.create', type, message)
 }

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri } from '../../../src/parts/Host/Host.ts'
+import { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri, showNotification } from '../../../src/parts/Host/Host.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -37,6 +37,7 @@ test('host helpers execute renderer commands through extension management', asyn
   strictEqual(await confirm('Discard changes?'), true)
   await handleWorkspaceRefresh()
   await openUri('/workspace/file.txt')
+  await showNotification('info', 'File created successfully')
 
   deepStrictEqual(invocations, [
     ['Workspace.getPath'],
@@ -44,5 +45,6 @@ test('host helpers execute renderer commands through extension management', asyn
     ['ConfirmPrompt.prompt', 'Discard changes?'],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', '/workspace/file.txt'],
+    ['Notification.create', 'info', 'File created successfully'],
   ])
 })


### PR DESCRIPTION
## Summary
- expose a typed showNotification helper from the isolated extension API
- route notifications through the existing renderer Notification.create command
- cover the renderer command invocation in host API tests

## Validation
- packages/extension-api: npm test
- packages/extension-api: npm run type-check
- packages/extension-api: npm run build
- npm run type-check
- npm run lint
- npm test
- npm run build