### PR TITLE
feature: add isolated debug provider api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -5,6 +5,7 @@ export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showQuickPick } from './parts/QuickPick/QuickPick.ts'
 export { getPreference, setPreference } from './parts/Preferences/Preferences.ts'
 export { registerCommand } from './parts/CommandRegistry/CommandRegistry.ts'
+export { registerDebugProvider, resetDebugProviderRegistry } from './parts/Debug/Debug.ts'
 export {
   executeCompletionProvider,
   executeResolveCompletionItemProvider,
@@ -126,6 +127,7 @@ export type {
   DiagnosticProviderRegistrySnapshot,
   RegisteredDiagnosticProvider,
 } from './parts/Diagnostic/Diagnostic.ts'
+export type { DebugEmitter, DebugProvider } from './parts/Debug/Debug.ts'
 export type { Disposable } from './parts/Disposable/Disposable.ts'
 export type {
   CreateElectronWebContentsViewOptions,

--- a/packages/extension-api/src/parts/Debug/Debug.ts
+++ b/packages/extension-api/src/parts/Debug/Debug.ts
@@ -1,0 +1,139 @@
+import type { Disposable } from '../Disposable/Disposable.ts'
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
+
+export interface DebugEmitter {
+  readonly handleChange: (params: unknown) => Promise<void>
+  readonly handlePaused: (params: unknown) => Promise<void>
+  readonly handleResumed: () => Promise<void>
+  readonly handleScriptParsed: (script: unknown) => Promise<void>
+}
+
+export interface DebugProvider {
+  readonly evaluate: (expression: string, callFrameId: string) => unknown
+  readonly getProperties: (objectId: string) => unknown
+  readonly id: string
+  readonly listProcesses: (path?: string) => unknown
+  readonly pause: () => unknown
+  readonly resume: () => unknown
+  readonly setPauseOnExceptions: (value: number) => unknown
+  readonly start: (emitter: DebugEmitter, path?: string) => unknown
+  readonly step: () => unknown
+  readonly stepInto: () => unknown
+  readonly stepOut: () => unknown
+  readonly stepOver: () => unknown
+}
+
+const providers: Record<string, DebugProvider> = Object.create(null)
+
+const requiredMethods = [
+  'evaluate',
+  'getProperties',
+  'listProcesses',
+  'pause',
+  'resume',
+  'setPauseOnExceptions',
+  'start',
+  'step',
+  'stepInto',
+  'stepOut',
+  'stepOver',
+] as const
+
+const assertDebugProvider = (provider: DebugProvider): void => {
+  if (!provider) {
+    throw new ExtensionApiError('debug provider is not defined')
+  }
+  if (typeof provider.id !== 'string' || provider.id.length === 0) {
+    throw new ExtensionApiError('debug provider is missing id')
+  }
+  for (const methodName of requiredMethods) {
+    if (typeof provider[methodName] !== 'function') {
+      throw new ExtensionApiError(`debug provider ${provider.id} is missing ${methodName} function`)
+    }
+  }
+  if (provider.id in providers) {
+    throw new ExtensionApiError(`debug provider ${provider.id} is already registered`)
+  }
+}
+
+const getProvider = (id: string): DebugProvider => {
+  const provider = providers[id]
+  if (!provider) {
+    throw new ExtensionApiError(`debug provider ${id} not found`)
+  }
+  return provider
+}
+
+const emitter: DebugEmitter = {
+  async handleChange(): Promise<void> {},
+  async handlePaused(params: unknown): Promise<void> {
+    await executeCommand('Debug.paused', params)
+  },
+  async handleResumed(): Promise<void> {
+    await executeCommand('Debug.resumed')
+  },
+  async handleScriptParsed(script: unknown): Promise<void> {
+    await executeCommand('Debug.scriptParsed', script)
+  },
+}
+
+export const registerDebugProvider = (provider: DebugProvider): Disposable => {
+  assertDebugProvider(provider)
+  providers[provider.id] = provider
+  return {
+    dispose(): void {
+      delete providers[provider.id]
+    },
+  }
+}
+
+export const executeDebugStart = async (id: string, path?: string): Promise<unknown> => {
+  return getProvider(id).start(emitter, path)
+}
+
+export const executeDebugListProcesses = async (id: string, path?: string): Promise<unknown> => {
+  return getProvider(id).listProcesses(path)
+}
+
+export const executeDebugResume = async (id: string): Promise<unknown> => {
+  return getProvider(id).resume()
+}
+
+export const executeDebugPause = async (id: string): Promise<unknown> => {
+  return getProvider(id).pause()
+}
+
+export const executeDebugStepOver = async (id: string): Promise<unknown> => {
+  return getProvider(id).stepOver()
+}
+
+export const executeDebugStepInto = async (id: string): Promise<unknown> => {
+  return getProvider(id).stepInto()
+}
+
+export const executeDebugStepOut = async (id: string): Promise<unknown> => {
+  return getProvider(id).stepOut()
+}
+
+export const executeDebugStep = async (id: string): Promise<unknown> => {
+  return getProvider(id).step()
+}
+
+export const executeDebugSetPauseOnExceptions = async (id: string, value: number): Promise<unknown> => {
+  return getProvider(id).setPauseOnExceptions(value)
+}
+
+export const executeDebugGetProperties = async (id: string, objectId: string): Promise<unknown> => {
+  return getProvider(id).getProperties(objectId)
+}
+
+export const executeDebugEvaluate = async (id: string, expression: string, callFrameId: string): Promise<unknown> => {
+  return getProvider(id).evaluate(expression, callFrameId)
+}
+
+export const resetDebugProviderRegistry = (): void => {
+  for (const id of Object.keys(providers)) {
+    delete providers[id]
+  }
+}

--- a/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
+++ b/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
@@ -1,5 +1,18 @@
 import { executeCommand, getCommandRegistrySnapshot } from '../CommandRegistry/CommandRegistry.ts'
 import { executeCompletionProvider, executeResolveCompletionItemProvider, getCompletionProviderRegistrySnapshot } from '../Completion/Completion.ts'
+import {
+  executeDebugEvaluate,
+  executeDebugGetProperties,
+  executeDebugListProcesses,
+  executeDebugPause,
+  executeDebugResume,
+  executeDebugSetPauseOnExceptions,
+  executeDebugStart,
+  executeDebugStep,
+  executeDebugStepInto,
+  executeDebugStepOut,
+  executeDebugStepOver,
+} from '../Debug/Debug.ts'
 import { executeDiagnosticProvider, getDiagnosticProviderRegistrySnapshot } from '../Diagnostic/Diagnostic.ts'
 import {
   executeFileSystemProviderGetPathSeparator,
@@ -87,4 +100,15 @@ export const commandMap = {
   'ExtensionApi.getViewRegistrySnapshot': getViewRegistrySnapshot,
   'ExtensionApi.renderViewInstance': renderViewInstance,
   'ExtensionApi.saveViewInstanceState': saveViewInstanceState,
+  'ExtensionHostDebug.evaluate': executeDebugEvaluate,
+  'ExtensionHostDebug.getProperties': executeDebugGetProperties,
+  'ExtensionHostDebug.listProcesses': executeDebugListProcesses,
+  'ExtensionHostDebug.pause': executeDebugPause,
+  'ExtensionHostDebug.resume': executeDebugResume,
+  'ExtensionHostDebug.setPauseOnExceptions': executeDebugSetPauseOnExceptions,
+  'ExtensionHostDebug.start': executeDebugStart,
+  'ExtensionHostDebug.step': executeDebugStep,
+  'ExtensionHostDebug.stepInto': executeDebugStepInto,
+  'ExtensionHostDebug.stepOut': executeDebugStepOut,
+  'ExtensionHostDebug.stepOver': executeDebugStepOver,
 }

--- a/packages/extension-api/test/parts/Debug/Debug.test.ts
+++ b/packages/extension-api/test/parts/Debug/Debug.test.ts
@@ -1,0 +1,109 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import {
+  executeDebugEvaluate,
+  executeDebugGetProperties,
+  executeDebugListProcesses,
+  executeDebugPause,
+  executeDebugResume,
+  executeDebugSetPauseOnExceptions,
+  executeDebugStart,
+  executeDebugStep,
+  executeDebugStepInto,
+  executeDebugStepOut,
+  executeDebugStepOver,
+  registerDebugProvider,
+  resetDebugProviderRegistry,
+  type DebugEmitter,
+  type DebugProvider,
+} from '../../../src/parts/Debug/Debug.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+const createProvider = (overrides: Partial<DebugProvider> = {}): DebugProvider => {
+  return {
+    evaluate: () => 'evaluate',
+    getProperties: () => 'properties',
+    id: 'node-debug',
+    listProcesses: () => [],
+    pause: () => 'pause',
+    resume: () => 'resume',
+    setPauseOnExceptions: () => 'set-pause',
+    start: () => 'start',
+    step: () => 'step',
+    stepInto: () => 'step-into',
+    stepOut: () => 'step-out',
+    stepOver: () => 'step-over',
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+  resetDebugProviderRegistry()
+})
+
+test('registerDebugProvider exposes provider methods', async () => {
+  registerDebugProvider(createProvider())
+
+  deepStrictEqual(await executeDebugListProcesses('node-debug', '/workspace'), [])
+  strictEqual(await executeDebugPause('node-debug'), 'pause')
+  strictEqual(await executeDebugResume('node-debug'), 'resume')
+  strictEqual(await executeDebugStep('node-debug'), 'step')
+  strictEqual(await executeDebugStepInto('node-debug'), 'step-into')
+  strictEqual(await executeDebugStepOut('node-debug'), 'step-out')
+  strictEqual(await executeDebugStepOver('node-debug'), 'step-over')
+  strictEqual(await executeDebugSetPauseOnExceptions('node-debug', 2), 'set-pause')
+  strictEqual(await executeDebugGetProperties('node-debug', 'object-1'), 'properties')
+  strictEqual(await executeDebugEvaluate('node-debug', '1 + 1', 'frame-1'), 'evaluate')
+})
+
+test('executeDebugStart supplies a host event emitter', async () => {
+  const invocations: unknown[][] = []
+  let receivedEmitter: DebugEmitter | undefined
+  let receivedPath: string | undefined
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...params: readonly unknown[]): Promise<void> {
+      invocations.push([id, ...params])
+    },
+  })
+  registerDebugProvider(
+    createProvider({
+      async start(emitter, path) {
+        receivedEmitter = emitter
+        receivedPath = path
+      },
+    }),
+  )
+
+  await executeDebugStart('node-debug', '/workspace')
+  strictEqual(receivedPath, '/workspace')
+  await receivedEmitter!.handlePaused({ reason: 'breakpoint' })
+  await receivedEmitter!.handleResumed()
+  await receivedEmitter!.handleScriptParsed({ scriptId: '1' })
+  await receivedEmitter!.handleChange({ type: 'paused' })
+  deepStrictEqual(invocations, [['Debug.paused', { reason: 'breakpoint' }], ['Debug.resumed'], ['Debug.scriptParsed', { scriptId: '1' }]])
+})
+
+test('registerDebugProvider returns a disposable registration', async () => {
+  const disposable = registerDebugProvider(createProvider())
+  disposable.dispose()
+  await rejects(executeDebugPause('node-debug'), /debug provider node-debug not found/)
+})
+
+test('registerDebugProvider rejects invalid registrations', () => {
+  throws(() => registerDebugProvider(undefined as never), /debug provider is not defined/)
+  throws(() => registerDebugProvider(createProvider({ id: '' })), /debug provider is missing id/)
+  throws(() => registerDebugProvider(createProvider({ pause: undefined as never })), /debug provider node-debug is missing pause function/)
+})
+
+test('registerDebugProvider rejects duplicate ids', () => {
+  registerDebugProvider(createProvider())
+  throws(() => registerDebugProvider(createProvider()), /debug provider node-debug is already registered/)
+})

--- a/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
+++ b/packages/extension-api/test/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.test.ts
@@ -35,3 +35,10 @@ test('commandMap exposes file system provider commands', () => {
   strictEqual(typeof commandMap['ExtensionApi.executeFileSystemProviderReadFile'], 'function')
   strictEqual(typeof commandMap['ExtensionApi.getFileSystemProviderRegistrySnapshot'], 'function')
 })
+
+test('commandMap exposes debug provider commands', () => {
+  strictEqual(typeof commandMap['ExtensionHostDebug.start'], 'function')
+  strictEqual(typeof commandMap['ExtensionHostDebug.pause'], 'function')
+  strictEqual(typeof commandMap['ExtensionHostDebug.resume'], 'function')
+  strictEqual(typeof commandMap['ExtensionHostDebug.evaluate'], 'function')
+})


### PR DESCRIPTION
Summary:
- add typed debug provider registration to the isolated extension API
- expose the existing debug command surface from isolated workers
- forward pause, resume, and script events to the host