### PR TITLE
feature: support web worker content security policy

### DIFF
--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -3,6 +3,7 @@ import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
 export interface CreateRpcOptions {
   readonly commandMap?: Record<string, unknown>
+  readonly contentSecurityPolicy?: string
   readonly name?: string
   readonly url: string
 }
@@ -13,8 +14,8 @@ export interface CreateNodeRpcOptions {
   readonly path?: string
 }
 
-const sendMessagePortToWebWorker = async (port: MessagePort, name: string, url: string): Promise<void> => {
-  await ExtensionManagementWorker.invokeAndTransfer('Extensions.createWebViewWorkerRpc2', { name, url }, port)
+const sendMessagePortToWebWorker = async (port: MessagePort, contentSecurityPolicy: string, name: string, url: string): Promise<void> => {
+  await ExtensionManagementWorker.invokeAndTransfer('Extensions.createWebViewWorkerRpc2', { contentSecurityPolicy, name, url }, port)
 }
 
 const createMessagePortRpc = async (commandMap: Record<string, unknown>, send: (port: MessagePort) => Promise<void>): Promise<Rpc> => {
@@ -29,8 +30,8 @@ const createMessagePortRpc = async (commandMap: Record<string, unknown>, send: (
   return rpcPromise
 }
 
-export const createRpc = async ({ commandMap = {}, name = '', url }: CreateRpcOptions): Promise<Rpc> => {
-  return createMessagePortRpc(commandMap, (port) => sendMessagePortToWebWorker(port, name, url))
+export const createRpc = async ({ commandMap = {}, contentSecurityPolicy = '', name = '', url }: CreateRpcOptions): Promise<Rpc> => {
+  return createMessagePortRpc(commandMap, (port) => sendMessagePortToWebWorker(port, contentSecurityPolicy, name, url))
 }
 
 interface ResolvedNodeRpcOptions {

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -97,11 +97,18 @@ test('createRpc transfers a port and worker options', async () => {
 
   const rpc = await createRpc({
     commandMap: {},
+    contentSecurityPolicy: `default-src 'none'; script-src 'self' 'unsafe-eval';`,
     name: 'Git Worker',
     url: '/extensions/git/gitWorkerMain.js',
   })
 
   strictEqual(await rpc.invoke('Git.status'), 'ok')
-  deepStrictEqual(invocations, [{ name: 'Git Worker', url: '/extensions/git/gitWorkerMain.js' }])
+  deepStrictEqual(invocations, [
+    {
+      contentSecurityPolicy: `default-src 'none'; script-src 'self' 'unsafe-eval';`,
+      name: 'Git Worker',
+      url: '/extensions/git/gitWorkerMain.js',
+    },
+  ])
   await rpc.dispose()
 })


### PR DESCRIPTION
Adds an optional content security policy to extension-created web worker RPCs so callers can launch narrowly sandboxed workers.