### PR TITLE
feature: add object url file system API

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -25,7 +25,17 @@ export {
   registerFormattingProvider,
   resetFormattingProviderRegistry,
 } from './parts/Formatting/Formatting.ts'
-export { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from './parts/FileSystem/FileSystem.ts'
+export {
+  exists,
+  mkdir,
+  readAsObjectUrl,
+  readDirWithFileTypes,
+  readFile,
+  remove,
+  stat,
+  writeFile,
+  type ReadAsObjectUrlResult,
+} from './parts/FileSystem/FileSystem.ts'
 export {
   executeFileSystemProviderGetPathSeparator,
   executeFileSystemProviderIsReadonly,

--- a/packages/extension-api/src/parts/FileSystem/FileSystem.ts
+++ b/packages/extension-api/src/parts/FileSystem/FileSystem.ts
@@ -1,10 +1,43 @@
 import { ExtensionManagementWorker, FileSystemWorker } from '@lvce-editor/rpc-registry'
 import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+import { getPlatform } from '../Platform/Platform.ts'
 
 const MemfsPrefix = 'memfs://'
 
+export interface ReadAsObjectUrlResult {
+  readonly error: string
+  readonly objectUrl: string
+  readonly wasFound: boolean
+}
+
 const isMemory = (uri: string): boolean => {
   return uri.startsWith(MemfsPrefix)
+}
+
+const isHttp = (uri: string): boolean => {
+  return uri.startsWith('http://') || uri.startsWith('https://')
+}
+
+const getRemoteUrl = (uri: string): string => {
+  const withoutPrefix = uri.startsWith('file://') ? uri.slice('file://'.length) : uri
+  const normalized = withoutPrefix.replaceAll('\\', '/')
+  return normalized.startsWith('/') ? `/remote${normalized}` : `/remote/${normalized}`
+}
+
+const getObjectUrl = async (uri: string): Promise<string> => {
+  if (isHttp(uri)) {
+    return uri
+  }
+  const platform = await getPlatform()
+  if (platform === 'web') {
+    return (await executeCommand('Blob.getSrc', uri)) as string
+  }
+  return getRemoteUrl(uri)
+}
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error)
 }
 
 export const exists = async (uri: string): Promise<boolean> => {
@@ -20,6 +53,23 @@ export const readFile = async (uri: string): Promise<string> => {
     return ExtensionManagementWorker.invoke('ExtensionApi.readFile', uri)
   }
   return FileSystemWorker.readFile(uri)
+}
+
+export const readAsObjectUrl = async (uri: string): Promise<ReadAsObjectUrlResult> => {
+  try {
+    const objectUrl = await getObjectUrl(uri)
+    return {
+      error: '',
+      objectUrl,
+      wasFound: true,
+    }
+  } catch (error) {
+    return {
+      error: getErrorMessage(error),
+      objectUrl: '',
+      wasFound: false,
+    }
+  }
 }
 
 export const mkdir = async (uri: string): Promise<void> => {

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -66,10 +66,7 @@ test('readAsObjectUrl reads a web file as a browser object URL', async () => {
     objectUrl: 'blob:https://example.com/image-id',
     wasFound: true,
   })
-  deepStrictEqual(invocations, [
-    ['Layout.getPlatform'],
-    ['Blob.getSrc', 'html:///workspace/image.png'],
-  ])
+  deepStrictEqual(invocations, [['Layout.getPlatform'], ['Blob.getSrc', 'html:///workspace/image.png']])
 })
 
 test('readAsObjectUrl returns a remote URL for an Electron file', async () => {

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker, FileSystemWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { exists, mkdir, readDirWithFileTypes, readFile, remove, stat, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
+import { exists, mkdir, readAsObjectUrl, readDirWithFileTypes, readFile, remove, stat, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -45,6 +45,94 @@ test('readFile reads memfs files through the extension api host command', async 
 
   strictEqual(result, 'ignored.js')
   strictEqual(invokedUri, 'memfs:///workspace/.prettierignore')
+})
+
+test('readAsObjectUrl reads a web file as a browser object URL', async () => {
+  const invocations: [string, ...unknown[]][] = []
+  mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      if (id === 'Layout.getPlatform') {
+        return 1
+      }
+      return 'blob:https://example.com/image-id'
+    },
+  })
+
+  const result = await readAsObjectUrl('html:///workspace/image.png')
+
+  deepStrictEqual(result, {
+    error: '',
+    objectUrl: 'blob:https://example.com/image-id',
+    wasFound: true,
+  })
+  deepStrictEqual(invocations, [
+    ['Layout.getPlatform'],
+    ['Blob.getSrc', 'html:///workspace/image.png'],
+  ])
+})
+
+test('readAsObjectUrl returns a remote URL for an Electron file', async () => {
+  mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string): Promise<number> {
+      strictEqual(id, 'Layout.getPlatform')
+      return 2
+    },
+  })
+
+  const result = await readAsObjectUrl('file:///workspace/image.png')
+
+  deepStrictEqual(result, {
+    error: '',
+    objectUrl: '/remote/workspace/image.png',
+    wasFound: true,
+  })
+})
+
+test('readAsObjectUrl returns a remote URL for a Windows file', async () => {
+  mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string): Promise<number> {
+      strictEqual(id, 'Layout.getPlatform')
+      return 3
+    },
+  })
+
+  const result = await readAsObjectUrl('file:///C:\\workspace\\image.png')
+
+  deepStrictEqual(result, {
+    error: '',
+    objectUrl: '/remote/C:/workspace/image.png',
+    wasFound: true,
+  })
+})
+
+test('readAsObjectUrl preserves an HTTP URL', async () => {
+  const result = await readAsObjectUrl('https://example.com/image.png')
+
+  deepStrictEqual(result, {
+    error: '',
+    objectUrl: 'https://example.com/image.png',
+    wasFound: true,
+  })
+})
+
+test('readAsObjectUrl returns the error when the file cannot be read', async () => {
+  mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string): Promise<number> {
+      if (id === 'Layout.getPlatform') {
+        return 1
+      }
+      throw new Error('File not found')
+    },
+  })
+
+  const result = await readAsObjectUrl('html:///workspace/missing.png')
+
+  deepStrictEqual(result, {
+    error: 'File not found',
+    objectUrl: '',
+    wasFound: false,
+  })
 })
 
 test('exists checks through the file system worker', async () => {


### PR DESCRIPTION
Adds a structured file-system API for resolving browser object URLs on web and /remote URLs on Electron and remote platforms.