### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^17.0.3",
+        "@lvce-editor/eslint-config": "^17.5.0",
         "@lvce-editor/eslint-plugin-github-actions": "^11.2.0",
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.0",
         "knip": "^6.23.0",
         "prettier": "^3.9.1",
         "typescript": "^6.0.3"
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2976,11 +2976,14 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
-      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -2988,14 +2991,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
-        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
-        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
-        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
-        "@lvce-editor/eslint-plugin-regex": "17.0.3",
-        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
-        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
-        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -3010,9 +3014,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
-      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3038,9 +3042,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
-      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3048,11 +3052,21 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
-      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
       "version": "11.2.0",
@@ -3066,9 +3080,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
-      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3076,23 +3090,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
-      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
-      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
-      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3100,9 +3114,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
-      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7753,9 +7767,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -7765,7 +7779,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -7789,7 +7803,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^17.0.3",
+    "@lvce-editor/eslint-config": "^17.5.0",
     "@lvce-editor/eslint-plugin-github-actions": "^11.2.0",
-    "eslint": "^10.7.0",
+    "eslint": "^10.8.0",
     "knip": "^6.23.0",
     "prettier": "^3.9.1",
     "typescript": "^6.0.3"

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -215,11 +215,11 @@ test('registerView includes event listeners in registry snapshot', () => {
   const eventListeners = [
     {
       name: 'handleDragStart',
-      params: ['handleViewEvent', 'dragstart', 'event.target.name'],
+      params: ['handleDragStart', 'event.target.name'],
     },
     {
       name: 'handleDrop',
-      params: ['handleViewEvent', 'drop', 'event.target.name'],
+      params: ['handleDrop', 'event.target.name'],
       preventDefault: true,
       trackPointerEvents: ['handlePointerMove', 'handlePointerUp'],
     },


### PR DESCRIPTION
## Summary

- update `eslint` to 10.8.0
- update `@lvce-editor/eslint-config` to 17.5.0
- update the ViewRegistry drag/drop fixture to use dedicated event handlers
- refresh the npm lockfile

## Validation

- `npm ci`
- build and static build
- extension API: 186 tests
- extension host: 70 suites / 338 tests (11 intentionally skipped)
- type-check
- lint and formatting
- E2E: 50 passed, 74 intentionally skipped
- memory: 633,312 bytes
