### PR TITLE
feature: add preferred view locations

### DIFF
--- a/packages/e2e/fixtures/sample.isolated-extension-view-preferred-preview/extension.json
+++ b/packages/e2e/fixtures/sample.isolated-extension-view-preferred-preview/extension.json
@@ -1,0 +1,14 @@
+{
+  "browser": "main.ts",
+  "isolated": true,
+  "activation": ["onView:sample.views.preferredPreview"],
+  "views": [
+    {
+      "id": "sample.views.preferredPreview",
+      "title": "Preferred Preview",
+      "icon": "symbol-beaker",
+      "kind": "virtualDom",
+      "preferredLocation": "preview"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/sample.isolated-extension-view-preferred-preview/main.ts
+++ b/packages/e2e/fixtures/sample.isolated-extension-view-preferred-preview/main.ts
@@ -1,0 +1,30 @@
+import { activate as activateExtensionApi, registerView } from '@lvce-editor/api'
+
+const H1 = 5
+const Text = 12
+
+export const activate = (): void => {
+  activateExtensionApi()
+  registerView({
+    create() {
+      return {
+        render() {
+          return [
+            {
+              childCount: 1,
+              type: H1,
+            },
+            {
+              childCount: 0,
+              text: 'Preview content',
+              type: Text,
+            },
+          ]
+        },
+      }
+    },
+    id: 'sample.views.preferredPreview',
+    kind: 'virtualDom',
+    preferredLocation: 'preview',
+  })
+}

--- a/packages/e2e/src/sample.isolated-extension-view-preferred-preview.ts
+++ b/packages/e2e/src/sample.isolated-extension-view-preferred-preview.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'sample.isolated-extension-view-preferred-preview'
+
+export const skip = true
+
+export const test: Test = async ({ ActivityBar, expect, Extension, Locator }) => {
+  const uri = new URL(`../fixtures/${name}`, import.meta.url).toString()
+  await Extension.addWebExtension(uri)
+
+  const item = Locator('.ActivityBarItem[title="Preferred Preview"]')
+  await expect(item).toBeVisible()
+
+  await ActivityBar.toggleActivityBarItem('sample.views.preferredPreview')
+
+  const previewHeading = Locator('.Preview h1')
+  await expect(item).toHaveAttribute('aria-selected', 'true')
+  await expect(previewHeading).toBeVisible()
+  await expect(previewHeading).toHaveText('Preview content')
+}

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -114,6 +114,7 @@ export type {
   ViewContext,
   ViewEvent,
   ViewKind,
+  ViewPreferredLocation,
   MenuEntry,
   ViewRegistrySnapshot,
   ViewRenderResult,

--- a/packages/extension-api/src/parts/View/View.ts
+++ b/packages/extension-api/src/parts/View/View.ts
@@ -2,6 +2,8 @@ import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 
 export type ViewKind = 'virtualDom'
 
+export type ViewPreferredLocation = 'preview' | 'sideBar'
+
 export interface ViewContext {
   readonly requestRerender: () => Promise<void>
   readonly showContextMenu: (menuId: string, x: number, y: number) => Promise<void>
@@ -82,6 +84,7 @@ export interface View<State = unknown> {
   readonly id: string
   readonly kind?: ViewKind
   readonly name?: string
+  readonly preferredLocation?: ViewPreferredLocation
   readonly title?: string
 }
 
@@ -92,6 +95,7 @@ export interface RegisteredView {
   readonly id: string
   readonly kind?: ViewKind
   readonly name?: string
+  readonly preferredLocation: ViewPreferredLocation
   readonly title?: string
 }
 

--- a/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
+++ b/packages/extension-api/src/parts/ViewRegistry/ViewRegistry.ts
@@ -117,6 +117,9 @@ const assertView = (view: View<any>): void => {
   if (view.id in views) {
     throw new ExtensionApiError(`view ${view.id} is already registered`)
   }
+  if (view.preferredLocation !== undefined && view.preferredLocation !== 'preview' && view.preferredLocation !== 'sideBar') {
+    throw new ExtensionApiError(`view ${view.id} has invalid preferredLocation`)
+  }
   assertCommands(view)
   assertEventListeners(view)
 }
@@ -129,6 +132,7 @@ const toRegisteredView = (view: View<any>): RegisteredView => {
     icon: view.icon,
     id: view.id,
     name: view.name,
+    preferredLocation: view.preferredLocation || 'sideBar',
     title: displayName,
   }
   if (view.kind) {

--- a/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
+++ b/packages/extension-api/test/parts/ViewRegistry/ViewRegistry.test.ts
@@ -59,6 +59,7 @@ test('registerView registers and executes a view provider', () => {
         icon: 'symbol-beaker',
         id: 'sample.views.testing',
         name: undefined,
+        preferredLocation: 'sideBar',
         title: 'Testing',
       },
     ],
@@ -83,6 +84,7 @@ test('registerView uses displayName as canonical title in registry snapshot', ()
         icon: undefined,
         id: 'sample.views.testing',
         name: 'Testing Name',
+        preferredLocation: 'sideBar',
         title: 'Testing Display',
       },
     ],
@@ -105,6 +107,7 @@ test('registerView falls back from title for registry displayName', () => {
         icon: undefined,
         id: 'sample.views.testing',
         name: undefined,
+        preferredLocation: 'sideBar',
         title: 'Testing Title',
       },
     ],
@@ -126,6 +129,41 @@ test('registerView rejects duplicate id', () => {
   throws(() => {
     registerView(view)
   }, /view sample\.views\.testing is already registered/)
+})
+
+test('registerView includes preferred preview location in registry snapshot', () => {
+  registerView({
+    create() {
+      return 'created'
+    },
+    id: 'sample.views.testing',
+    preferredLocation: 'preview',
+  })
+
+  deepStrictEqual(getViewRegistrySnapshot(), {
+    views: [
+      {
+        displayName: undefined,
+        icon: undefined,
+        id: 'sample.views.testing',
+        name: undefined,
+        preferredLocation: 'preview',
+        title: undefined,
+      },
+    ],
+  })
+})
+
+test('registerView rejects invalid preferred location', () => {
+  throws(() => {
+    registerView({
+      create() {
+        return 'created'
+      },
+      id: 'sample.views.testing',
+      preferredLocation: 'panel',
+    } as any)
+  }, /view sample\.views\.testing has invalid preferredLocation/)
 })
 
 test('registerView registers and disposes view commands', () => {
@@ -205,6 +243,7 @@ test('registerView includes virtual dom kind in registry snapshot', () => {
         id: 'sample.views.testing',
         kind: 'virtualDom',
         name: undefined,
+        preferredLocation: 'sideBar',
         title: undefined,
       },
     ],
@@ -246,6 +285,7 @@ test('registerView includes event listeners in registry snapshot', () => {
         id: 'sample.views.testing',
         kind: 'virtualDom',
         name: undefined,
+        preferredLocation: 'sideBar',
         title: undefined,
       },
     ],


### PR DESCRIPTION
Adds an optional preferred view location to the extension API, defaulting to the sidebar. Includes registry validation and focused preview-location coverage.