### PR TITLE
feature: add file change handlers

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -37,6 +37,7 @@ export {
   writeFile,
   type ReadAsObjectUrlResult,
 } from './parts/FileSystem/FileSystem.ts'
+export { registerFileChangeHandler, type FileChangeHandler, type FileChanges } from './parts/FileChangeHandler/FileChangeHandler.ts'
 export {
   executeFileSystemProviderGetPathSeparator,
   executeFileSystemProviderIsReadonly,

--- a/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
+++ b/packages/extension-api/src/parts/ExtensionApiCommandMap/ExtensionApiCommandMap.ts
@@ -14,6 +14,7 @@ import {
   executeDebugStepOver,
 } from '../Debug/Debug.ts'
 import { executeDiagnosticProvider, getDiagnosticProviderRegistrySnapshot } from '../Diagnostic/Diagnostic.ts'
+import { handleFileChanges } from '../FileChangeHandler/FileChangeHandler.ts'
 import {
   executeFileSystemProviderGetPathSeparator,
   executeFileSystemProviderIsReadonly,
@@ -98,6 +99,7 @@ export const commandMap = {
   'ExtensionApi.getViewActionsDom': getViewActionsDom,
   'ExtensionApi.getViewMenuEntries': getViewMenuEntries,
   'ExtensionApi.getViewRegistrySnapshot': getViewRegistrySnapshot,
+  'ExtensionApi.handleFileChanges': handleFileChanges,
   'ExtensionApi.renderViewInstance': renderViewInstance,
   'ExtensionApi.saveViewInstanceState': saveViewInstanceState,
   'ExtensionHostDebug.evaluate': executeDebugEvaluate,

--- a/packages/extension-api/src/parts/FileChangeHandler/FileChangeHandler.ts
+++ b/packages/extension-api/src/parts/FileChangeHandler/FileChangeHandler.ts
@@ -1,0 +1,59 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import type { Disposable } from '../Disposable/Disposable.ts'
+import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
+
+type UriRename = readonly [oldUri: string, newUri: string]
+
+export interface FileChanges {
+  readonly changed?: readonly string[]
+  readonly deleted?: readonly string[]
+  readonly renamed?: readonly UriRename[]
+}
+
+export type FileChangeHandler = (changes: Readonly<FileChanges>) => unknown | Promise<unknown>
+
+const handlers = new Set<FileChangeHandler>()
+
+const registerWithExtensionManagement = (): void => {
+  void ExtensionManagementWorker.invoke('Extensions.registerFileChangeHandler')
+}
+
+const unregisterWithExtensionManagement = (): void => {
+  void ExtensionManagementWorker.invoke('Extensions.unregisterFileChangeHandler')
+}
+
+export const registerFileChangeHandler = (handler: FileChangeHandler): Disposable => {
+  if (typeof handler !== 'function') {
+    throw new ExtensionApiError('file change handler must be a function')
+  }
+  if (handlers.has(handler)) {
+    throw new ExtensionApiError('file change handler is already registered')
+  }
+  const wasEmpty = handlers.size === 0
+  handlers.add(handler)
+  if (wasEmpty) {
+    registerWithExtensionManagement()
+  }
+  return {
+    dispose(): void {
+      if (!handlers.delete(handler)) {
+        return
+      }
+      if (handlers.size === 0) {
+        unregisterWithExtensionManagement()
+      }
+    },
+  }
+}
+
+export const handleFileChanges = async (changes: Readonly<FileChanges> = {}): Promise<void> => {
+  await Promise.all(Array.from(handlers, async (handler) => handler(changes)))
+}
+
+export const resetFileChangeHandlers = (): void => {
+  if (handlers.size === 0) {
+    return
+  }
+  handlers.clear()
+  unregisterWithExtensionManagement()
+}

--- a/packages/extension-api/test/parts/FileChangeHandler/FileChangeHandler.test.ts
+++ b/packages/extension-api/test/parts/FileChangeHandler/FileChangeHandler.test.ts
@@ -1,0 +1,96 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/strict'
+import { afterEach, beforeEach, test } from 'node:test'
+import { handleFileChanges, registerFileChangeHandler, resetFileChangeHandlers } from '../../../src/parts/FileChangeHandler/FileChangeHandler.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+let registrations: string[] = []
+
+beforeEach(() => {
+  registrations = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.registerFileChangeHandler'(): void {
+      registrations.push('register')
+    },
+    'Extensions.unregisterFileChangeHandler'(): void {
+      registrations.push('unregister')
+    },
+  })
+})
+
+afterEach(() => {
+  resetFileChangeHandlers()
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('registerFileChangeHandler registers once and dispatches changes to all handlers', async () => {
+  const received: unknown[] = []
+  registerFileChangeHandler((changes) => {
+    received.push(['first', changes])
+  })
+  registerFileChangeHandler(async (changes) => {
+    received.push(['second', changes])
+  })
+  const changes = {
+    changed: ['file:///workspace/main.ts'],
+    deleted: ['file:///workspace/old.ts'],
+    renamed: [['file:///workspace/before.ts', 'file:///workspace/after.ts']] as const,
+  }
+
+  await handleFileChanges(changes)
+
+  deepStrictEqual(registrations, ['register'])
+  deepStrictEqual(received, [
+    ['first', changes],
+    ['second', changes],
+  ])
+})
+
+test('registerFileChangeHandler unregisters after the last handler is disposed', () => {
+  const first = registerFileChangeHandler(() => {})
+  const second = registerFileChangeHandler(() => {})
+
+  first.dispose()
+  deepStrictEqual(registrations, ['register'])
+  second.dispose()
+  second.dispose()
+
+  deepStrictEqual(registrations, ['register', 'unregister'])
+})
+
+test('registerFileChangeHandler rejects invalid and duplicate handlers', () => {
+  throws(() => {
+    // @ts-expect-error testing an invalid handler
+    registerFileChangeHandler(undefined)
+  }, /file change handler must be a function/)
+
+  const handler = (): void => {}
+  registerFileChangeHandler(handler)
+  throws(() => registerFileChangeHandler(handler), /file change handler is already registered/)
+})
+
+test('handleFileChanges waits for handlers and forwards failures', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  let completed = false
+  registerFileChangeHandler(async () => {
+    await promise
+    completed = true
+  })
+
+  const handling = handleFileChanges()
+  strictEqual(completed, false)
+  resolve()
+  await handling
+  strictEqual(completed, true)
+
+  resetFileChangeHandlers()
+  registerFileChangeHandler(async () => {
+    throw new Error('listener failed')
+  })
+  await rejects(() => handleFileChanges(), /listener failed/)
+})


### PR DESCRIPTION
Adds a disposable isolated extension API for registering file change handlers and dispatching workspace change payloads inside the extension worker.