### PR TITLE
feature: support quick pick item icons

### DIFF
--- a/packages/extension-api/src/parts/QuickPickItem/QuickPickItem.ts
+++ b/packages/extension-api/src/parts/QuickPickItem/QuickPickItem.ts
@@ -1,5 +1,6 @@
 export interface QuickPickItem {
   readonly description: string
+  readonly icon?: string
   readonly label: string
   readonly value: unknown
 }

--- a/packages/extension-host-worker/src/parts/ExtensionHostQuickPick/ExtensionHostQuickPick.ts
+++ b/packages/extension-host-worker/src/parts/ExtensionHostQuickPick/ExtensionHostQuickPick.ts
@@ -2,6 +2,7 @@ import { QuickPickWorker } from '@lvce-editor/rpc-registry'
 
 export interface QuickPickItem {
   readonly description: string
+  readonly icon?: string
   readonly label: string
   readonly value: unknown
 }
@@ -21,6 +22,9 @@ const validateQuickPickItem = (item: QuickPickItem): void => {
   }
   if (typeof item.description !== 'string') {
     throw new TypeError('quick pick item.description must be a string')
+  }
+  if (item.icon !== undefined && typeof item.icon !== 'string') {
+    throw new TypeError('quick pick item.icon must be a string')
   }
   if (!('value' in item)) {
     throw new TypeError('quick pick item.value is required')

--- a/packages/extension-host-worker/test/ExtensionHostQuickPick.test.ts
+++ b/packages/extension-host-worker/test/ExtensionHostQuickPick.test.ts
@@ -27,6 +27,7 @@ test('showQuickPick', async () => {
     },
     {
       description: 'Remote branch',
+      icon: 'Cloud',
       label: 'branch 2',
       value: 'branch-2',
     },
@@ -85,4 +86,19 @@ test('showQuickPick - missing description', async () => {
       ],
     }),
   ).rejects.toThrow(new TypeError('quick pick item.description must be a string'))
+})
+
+test('showQuickPick - invalid icon', async () => {
+  await expect(
+    ExtensionHostQuickPick.showQuickPick({
+      items: [
+        {
+          description: 'Remote branch',
+          icon: 2,
+          label: 'branch 1',
+          value: 'branch-1',
+        } as any,
+      ],
+    }),
+  ).rejects.toThrow(new TypeError('quick pick item.icon must be a string'))
 })


### PR DESCRIPTION
Summary:
- expose optional icons on isolated quick pick items
- validate icon types before forwarding items