### PR TITLE
feature: expose isolated output channel logs

### DIFF
--- a/packages/build/test/IsolatedExtensionApiTreeShaking.test.ts
+++ b/packages/build/test/IsolatedExtensionApiTreeShaking.test.ts
@@ -55,8 +55,9 @@ test('debug bundle includes debug commands only', async () => {
   doesNotMatch(bundle, /ExtensionApi\.executeHoverProvider/)
 })
 
-test('output-channel bundle includes its snapshot command only', async () => {
+test('output-channel bundle includes its output channel commands only', async () => {
   const bundle = await readBundle('output-channel')
+  match(bundle, /ExtensionApi\.getOutputChannelLogs/)
   match(bundle, /ExtensionApi\.getOutputChannelRegistrySnapshot/)
   doesNotMatch(bundle, /ExtensionApi\.executeCompletionProvider/)
   doesNotMatch(bundle, /ExtensionHostDebug\.evaluate/)

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -107,7 +107,12 @@ export {
   resetViewRegistry,
   saveViewInstanceState,
 } from './parts/ViewRegistry/ViewRegistry.ts'
-export { createOutputChannel, getOutputChannelRegistrySnapshot, resetOutputChannelRegistry } from './parts/OutputChannel/OutputChannel.ts'
+export {
+  createOutputChannel,
+  getOutputChannelLogs,
+  getOutputChannelRegistrySnapshot,
+  resetOutputChannelRegistry,
+} from './parts/OutputChannel/OutputChannel.ts'
 export {
   getStatusBarItemProviderRegistrySnapshot,
   registerStatusBarItemProvider,

--- a/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
+++ b/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
@@ -80,7 +80,12 @@ export const getOutputChannelRegistrySnapshot = (): OutputChannelRegistrySnapsho
   }
 }
 
+export const getOutputChannelLogs = (id: string): string | undefined => {
+  return outputChannelLogs[id]
+}
+
 const commandMap = {
+  'ExtensionApi.getOutputChannelLogs': getOutputChannelLogs,
   'ExtensionApi.getOutputChannelRegistrySnapshot': getOutputChannelRegistrySnapshot,
 }
 

--- a/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
+++ b/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
@@ -3,6 +3,7 @@ import { afterEach, test } from 'node:test'
 import {
   activateOutputChannels,
   createOutputChannel,
+  getOutputChannelLogs,
   getOutputChannelRegistrySnapshot,
   resetOutputChannelRegistry,
 } from '../../../src/parts/OutputChannel/OutputChannel.ts'
@@ -160,6 +161,19 @@ test('getLogs returns output channel logs', async () => {
   const logs = await output.getLogs()
 
   strictEqual(logs, 'sample\nlogs')
+})
+
+test('getOutputChannelLogs returns output channel logs by id', async () => {
+  const output = createOutputChannel('sample-output')
+  activateOutputChannels()
+  await output.appendLine('sample')
+  await output.append('logs')
+
+  strictEqual(getOutputChannelLogs('sample-output'), 'sample\nlogs')
+})
+
+test('getOutputChannelLogs returns undefined for an unknown id', () => {
+  strictEqual(getOutputChannelLogs('unknown-output'), undefined)
 })
 
 test('multiple channels invoke with their own ids', async () => {


### PR DESCRIPTION
Adds a capability-scoped ExtensionApi command for reading an isolated output channel by id.

This lets extension-management-worker route output-view reads to the matching isolated worker without an extension-host-worker port.