### PR TITLE
feature: clear isolated output channels

### DIFF
--- a/packages/build/test/IsolatedExtensionApiTreeShaking.test.ts
+++ b/packages/build/test/IsolatedExtensionApiTreeShaking.test.ts
@@ -57,6 +57,7 @@ test('debug bundle includes debug commands only', async () => {
 
 test('output-channel bundle includes its output channel commands only', async () => {
   const bundle = await readBundle('output-channel')
+  match(bundle, /ExtensionApi\.clearOutputChannel/)
   match(bundle, /ExtensionApi\.getOutputChannelLogs/)
   match(bundle, /ExtensionApi\.getOutputChannelRegistrySnapshot/)
   doesNotMatch(bundle, /ExtensionApi\.executeCompletionProvider/)

--- a/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
+++ b/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
@@ -84,7 +84,16 @@ export const getOutputChannelLogs = (id: string): string | undefined => {
   return outputChannelLogs[id]
 }
 
+export const clearOutputChannel = (id: string): boolean => {
+  if (!(id in outputChannelLogs)) {
+    return false
+  }
+  outputChannelLogs[id] = ''
+  return true
+}
+
 const commandMap = {
+  'ExtensionApi.clearOutputChannel': clearOutputChannel,
   'ExtensionApi.getOutputChannelLogs': getOutputChannelLogs,
   'ExtensionApi.getOutputChannelRegistrySnapshot': getOutputChannelRegistrySnapshot,
 }

--- a/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
+++ b/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/stric
 import { afterEach, test } from 'node:test'
 import {
   activateOutputChannels,
+  clearOutputChannel,
   createOutputChannel,
   getOutputChannelLogs,
   getOutputChannelRegistrySnapshot,
@@ -174,6 +175,19 @@ test('getOutputChannelLogs returns output channel logs by id', async () => {
 
 test('getOutputChannelLogs returns undefined for an unknown id', () => {
   strictEqual(getOutputChannelLogs('unknown-output'), undefined)
+})
+
+test('clearOutputChannel clears output channel logs by id', async () => {
+  const output = createOutputChannel('sample-output')
+  activateOutputChannels()
+  await output.append('sample logs')
+
+  strictEqual(clearOutputChannel('sample-output'), true)
+  strictEqual(getOutputChannelLogs('sample-output'), '')
+})
+
+test('clearOutputChannel returns false for an unknown id', () => {
+  strictEqual(clearOutputChannel('unknown-output'), false)
 })
 
 test('multiple channels invoke with their own ids', async () => {


### PR DESCRIPTION
Summary:
- expose a capability-scoped command for clearing one isolated output channel
- cover registered and unknown channels and preserve output API tree shaking

Validation:
- npm test
- npm run type-check
- npm run lint
- npm run build
- npm run build:static