### PR TITLE
Restrict isolated Node RPC creation

### DIFF
--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -1,4 +1,4 @@
-import { MessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { MessagePortRpcParent, type Rpc, WebSocketRpcParent } from '@lvce-editor/rpc'
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
 export interface CreateRpcOptions {
@@ -9,9 +9,7 @@ export interface CreateRpcOptions {
 }
 
 export interface CreateNodeRpcOptions {
-  readonly id?: string
-  readonly name?: string
-  readonly path?: string
+  readonly id: string
 }
 
 const sendMessagePortToWebWorker = async (port: MessagePort, contentSecurityPolicy: string, name: string, url: string): Promise<void> => {
@@ -34,35 +32,93 @@ export const createRpc = async ({ commandMap = {}, contentSecurityPolicy = '', n
   return createMessagePortRpc(commandMap, (port) => sendMessagePortToWebWorker(port, contentSecurityPolicy, name, url))
 }
 
-interface ResolvedNodeRpcOptions {
+interface WebSocketConnectionInfo {
+  readonly protocols: string[]
+  readonly type: 'websocket'
+  readonly url: string
+}
+
+interface MessagePortConnectionInfo {
+  readonly type: 'message-port'
+}
+
+interface LegacyProxyConnectionInfo {
+  readonly type: 'legacy-proxy'
+}
+
+interface OldLegacyProxyConnectionInfo {
   readonly name: string
   readonly path: string
+  readonly type: 'old-legacy-proxy'
 }
 
-const resolveNodeRpcOptions = async ({ id, name = '', path }: CreateNodeRpcOptions): Promise<ResolvedNodeRpcOptions> => {
-  if (id) {
-    return ExtensionManagementWorker.invoke('Extensions.getNodeRpcInfo', id) as Promise<ResolvedNodeRpcOptions>
-  }
-  if (path) {
-    return { name, path }
-  }
-  throw new TypeError('createNodeRpc requires an id or path')
+type NodeRpcConnectionInfo = LegacyProxyConnectionInfo | MessagePortConnectionInfo | OldLegacyProxyConnectionInfo | WebSocketConnectionInfo
+
+const isMissingCommand = (error: unknown, command: string): boolean => {
+  return error instanceof Error && error.message.includes(command) && /command not found|not found/i.test(error.message)
 }
 
-export const createNodeRpc = async (options: CreateNodeRpcOptions): Promise<Rpc> => {
-  const { name, path } = await resolveNodeRpcOptions(options)
-  const rpcId = await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.create', name, path)
-  const invoke = (method: string, ...params: readonly any[]): Promise<any> => {
-    return ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.invoke', rpcId, method, ...params)
+const getNodeRpcConnection = async (id: string): Promise<NodeRpcConnectionInfo> => {
+  if (!id) {
+    throw new TypeError('createNodeRpc requires an id')
   }
+  try {
+    const connectionInfo = (await ExtensionManagementWorker.invoke('Extensions.createNodeRpcConnection', id)) as NodeRpcConnectionInfo
+    return connectionInfo
+  } catch (error) {
+    if (!isMissingCommand(error, 'Extensions.createNodeRpcConnection')) {
+      throw error
+    }
+    const { name, path } = (await ExtensionManagementWorker.invoke('Extensions.getNodeRpcInfo', id)) as {
+      readonly name: string
+      readonly path: string
+    }
+    return { name, path, type: 'old-legacy-proxy' }
+  }
+}
+
+const createProxyRpc = (invoke: (method: string, ...params: readonly any[]) => Promise<any>, dispose: () => Promise<void>): Rpc => {
   return {
-    async dispose(): Promise<void> {
-      await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.dispose', rpcId)
-    },
+    dispose,
     invoke,
     invokeAndTransfer: invoke,
     send(method: string, ...params: readonly any[]): void {
       void invoke(method, ...params)
     },
   }
+}
+
+const createLegacyProxyRpc = async (id: string): Promise<Rpc> => {
+  const rpcId = await ExtensionManagementWorker.invoke('Extensions.createLegacyNodeRpc', id)
+  return createProxyRpc(
+    (method, ...params) => ExtensionManagementWorker.invoke('Extensions.invokeLegacyNodeRpc', rpcId, method, ...params),
+    () => ExtensionManagementWorker.invoke('Extensions.disposeLegacyNodeRpc', rpcId) as Promise<void>,
+  )
+}
+
+const createOldLegacyProxyRpc = async (name: string, path: string): Promise<Rpc> => {
+  const rpcId = await ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.create', name, path)
+  return createProxyRpc(
+    (method, ...params) => ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.invoke', rpcId, method, ...params),
+    () => ExtensionManagementWorker.invoke('Extensions.executeCommand', 'ExtensionNodeRpc.dispose', rpcId) as Promise<void>,
+  )
+}
+
+export const createNodeRpc = async ({ id }: CreateNodeRpcOptions): Promise<Rpc> => {
+  const connectionInfo = await getNodeRpcConnection(id)
+  if (connectionInfo.type === 'message-port') {
+    return createMessagePortRpc({}, (port) => ExtensionManagementWorker.invokeAndTransfer('Extensions.createNodeRpcMessagePort', id, port))
+  }
+  if (connectionInfo.type === 'legacy-proxy') {
+    return createLegacyProxyRpc(id)
+  }
+  if (connectionInfo.type === 'old-legacy-proxy') {
+    return createOldLegacyProxyRpc(connectionInfo.name, connectionInfo.path)
+  }
+  const { protocols, url } = connectionInfo
+  const webSocket = new WebSocket(url, protocols)
+  return WebSocketRpcParent.create({
+    commandMap: {},
+    webSocket,
+  })
 }

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -8,75 +8,153 @@ interface MockRpcDisposable {
   [Symbol.dispose](): void
 }
 
+class MockWebSocket extends EventTarget {
+  static readonly OPEN = 1
+  static readonly instances: MockWebSocket[] = []
+  readonly protocols: string[]
+  readonly readyState = MockWebSocket.OPEN
+  readonly url: string
+
+  constructor(url: string, protocols: string[]) {
+    super()
+    this.url = url
+    this.protocols = protocols
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => this.dispatchEvent(new Event('open')))
+  }
+
+  close(): void {}
+  send(): void {}
+}
+
 let mockRpc: MockRpcDisposable | undefined
+const originalWebSocket = WebSocket
 
 afterEach(() => {
   mockRpc?.[Symbol.dispose]()
   mockRpc = undefined
+  MockWebSocket.instances.length = 0
+  globalThis.WebSocket = originalWebSocket
 })
 
-test('createNodeRpc proxies calls through the renderer worker', async () => {
+test('createNodeRpc opens the authorized websocket directly', async () => {
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
   const invocations: unknown[][] = []
   mockRpc = ExtensionManagementWorker.registerMockRpc({
-    async 'Extensions.executeCommand'(id: string, ...params: readonly unknown[]): Promise<unknown> {
-      invocations.push([id, ...params])
-      if (id === 'ExtensionNodeRpc.create') {
-        return 42
+    async 'Extensions.createNodeRpcConnection'(id: string): Promise<unknown> {
+      invocations.push(['Extensions.createNodeRpcConnection', id])
+      return {
+        protocols: ['lvce-rpc', 'lvce-capability.token'],
+        type: 'websocket',
+        url: 'wss://example.com/websocket/capability',
       }
-      if (id === 'ExtensionNodeRpc.invoke') {
-        return 'ok'
-      }
-      return undefined
     },
   })
 
-  const rpc = await createNodeRpc({
-    name: 'Git',
-    path: '/extensions/git/node/gitClient.js',
+  const rpc = await createNodeRpc({ id: 'git-client' })
+
+  deepStrictEqual(invocations, [['Extensions.createNodeRpcConnection', 'git-client']])
+  strictEqual(MockWebSocket.instances[0].url, 'wss://example.com/websocket/capability')
+  deepStrictEqual(MockWebSocket.instances[0].protocols, ['lvce-rpc', 'lvce-capability.token'])
+  await rpc.dispose()
+})
+
+test('createNodeRpc transfers a restricted message port in Electron', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.createNodeRpcConnection'(id: string): Promise<unknown> {
+      invocations.push(['Extensions.createNodeRpcConnection', id])
+      return { type: 'message-port' }
+    },
+    async 'Extensions.createNodeRpcMessagePort'(id: string, port: MessagePort): Promise<void> {
+      invocations.push(['Extensions.createNodeRpcMessagePort', id])
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'Git.status'(): string {
+            return 'ok'
+          },
+        },
+        messagePort: port,
+      })
+    },
   })
+
+  const rpc = await createNodeRpc({ id: 'git-client' })
+
+  strictEqual(await rpc.invoke('Git.status'), 'ok')
+  deepStrictEqual(invocations, [
+    ['Extensions.createNodeRpcConnection', 'git-client'],
+    ['Extensions.createNodeRpcMessagePort', 'git-client'],
+  ])
+  await rpc.dispose()
+})
+
+test('createNodeRpc requires an id', async () => {
+  await rejects(createNodeRpc({ id: '' }), new TypeError('createNodeRpc requires an id'))
+})
+
+test('createNodeRpc uses the bound compatibility proxy with an older renderer', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.createLegacyNodeRpc'(id: string): Promise<number> {
+      invocations.push(['create', id])
+      return 42
+    },
+    async 'Extensions.createNodeRpcConnection'(): Promise<unknown> {
+      return { type: 'legacy-proxy' }
+    },
+    async 'Extensions.disposeLegacyNodeRpc'(rpcId: number): Promise<void> {
+      invocations.push(['dispose', rpcId])
+    },
+    async 'Extensions.invokeLegacyNodeRpc'(rpcId: number, method: string): Promise<string> {
+      invocations.push(['invoke', rpcId, method])
+      return 'ok'
+    },
+  })
+
+  const rpc = await createNodeRpc({ id: 'git-client' })
 
   strictEqual(await rpc.invoke('Git.status'), 'ok')
   await rpc.dispose()
   deepStrictEqual(invocations, [
-    ['ExtensionNodeRpc.create', 'Git', '/extensions/git/node/gitClient.js'],
-    ['ExtensionNodeRpc.invoke', 42, 'Git.status'],
-    ['ExtensionNodeRpc.dispose', 42],
+    ['create', 'git-client'],
+    ['invoke', 42, 'Git.status'],
+    ['dispose', 42],
   ])
 })
 
-test('createNodeRpc resolves a declared rpc entry', async () => {
+test('createNodeRpc remains compatible with older extension management', async () => {
   const invocations: unknown[][] = []
   mockRpc = ExtensionManagementWorker.registerMockRpc({
-    async 'Extensions.executeCommand'(id: string, ...params: readonly unknown[]): Promise<unknown> {
-      invocations.push([id, ...params])
-      if (id === 'ExtensionNodeRpc.create') {
-        return 42
+    async 'Extensions.createNodeRpcConnection'(): Promise<never> {
+      throw new Error('Command not found Extensions.createNodeRpcConnection')
+    },
+    async 'Extensions.executeCommand'(command: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([command, ...args])
+      if (command === 'ExtensionNodeRpc.create') {
+        return 7
+      }
+      if (command === 'ExtensionNodeRpc.invoke') {
+        return 'ok'
       }
       return undefined
     },
-    async 'Extensions.getNodeRpcInfo'(id: string): Promise<{ name: string; path: string }> {
-      invocations.push(['Extensions.getNodeRpcInfo', id])
-      return {
-        name: 'Git',
-        path: '/extensions/git/node/gitClient.js',
-      }
+    async 'Extensions.getNodeRpcInfo'(id: string): Promise<unknown> {
+      invocations.push(['get-info', id])
+      return { name: 'Git Client', path: '/extensions/git/client.js' }
     },
   })
 
-  const rpc = await createNodeRpc({
-    id: 'git-client',
-  })
+  const rpc = await createNodeRpc({ id: 'git-client' })
 
+  strictEqual(await rpc.invoke('Git.status'), 'ok')
   await rpc.dispose()
   deepStrictEqual(invocations, [
-    ['Extensions.getNodeRpcInfo', 'git-client'],
-    ['ExtensionNodeRpc.create', 'Git', '/extensions/git/node/gitClient.js'],
-    ['ExtensionNodeRpc.dispose', 42],
+    ['get-info', 'git-client'],
+    ['ExtensionNodeRpc.create', 'Git Client', '/extensions/git/client.js'],
+    ['ExtensionNodeRpc.invoke', 7, 'Git.status'],
+    ['ExtensionNodeRpc.dispose', 7],
   ])
-})
-
-test('createNodeRpc requires an id or path', async () => {
-  await rejects(createNodeRpc({}), new TypeError('createNodeRpc requires an id or path'))
 })
 
 test('createRpc transfers a port and worker options', async () => {


### PR DESCRIPTION
Exposes only ID-based Node RPC creation to isolated extensions, uses direct authorized WebSockets or restricted Electron ports, and preserves a bounded compatibility proxy for older editor releases.