### PR TITLE
fix: support legacy node rpc fallback

### DIFF
--- a/packages/extension-api/src/parts/Rpc/Rpc.ts
+++ b/packages/extension-api/src/parts/Rpc/Rpc.ts
@@ -10,6 +10,8 @@ export interface CreateRpcOptions {
 
 export interface CreateNodeRpcOptions {
   readonly id: string
+  readonly legacyName?: string
+  readonly legacyPath?: string
 }
 
 const sendMessagePortToWebWorker = async (port: MessagePort, contentSecurityPolicy: string, name: string, url: string): Promise<void> => {
@@ -58,7 +60,7 @@ const isMissingCommand = (error: unknown, command: string): boolean => {
   return error instanceof Error && error.message.includes(command) && /command not found|not found/i.test(error.message)
 }
 
-const getNodeRpcConnection = async (id: string): Promise<NodeRpcConnectionInfo> => {
+const getNodeRpcConnection = async ({ id, legacyName = '', legacyPath }: CreateNodeRpcOptions): Promise<NodeRpcConnectionInfo> => {
   if (!id) {
     throw new TypeError('createNodeRpc requires an id')
   }
@@ -68,6 +70,9 @@ const getNodeRpcConnection = async (id: string): Promise<NodeRpcConnectionInfo> 
   } catch (error) {
     if (!isMissingCommand(error, 'Extensions.createNodeRpcConnection')) {
       throw error
+    }
+    if (legacyPath) {
+      return { name: legacyName, path: legacyPath, type: 'old-legacy-proxy' }
     }
     const { name, path } = (await ExtensionManagementWorker.invoke('Extensions.getNodeRpcInfo', id)) as {
       readonly name: string
@@ -104,8 +109,9 @@ const createOldLegacyProxyRpc = async (name: string, path: string): Promise<Rpc>
   )
 }
 
-export const createNodeRpc = async ({ id }: CreateNodeRpcOptions): Promise<Rpc> => {
-  const connectionInfo = await getNodeRpcConnection(id)
+export const createNodeRpc = async (options: CreateNodeRpcOptions): Promise<Rpc> => {
+  const { id } = options
+  const connectionInfo = await getNodeRpcConnection(options)
   if (connectionInfo.type === 'message-port') {
     return createMessagePortRpc({}, (port) => ExtensionManagementWorker.invokeAndTransfer('Extensions.createNodeRpcMessagePort', id, port))
   }

--- a/packages/extension-api/test/parts/Rpc/Rpc.test.ts
+++ b/packages/extension-api/test/parts/Rpc/Rpc.test.ts
@@ -157,6 +157,39 @@ test('createNodeRpc remains compatible with older extension management', async (
   ])
 })
 
+test('createNodeRpc uses caller-provided compatibility info when manifest lookup is unavailable', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.createNodeRpcConnection'(): Promise<never> {
+      throw new Error('Command not found Extensions.createNodeRpcConnection')
+    },
+    async 'Extensions.executeCommand'(command: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([command, ...args])
+      if (command === 'ExtensionNodeRpc.create') {
+        return 7
+      }
+      if (command === 'ExtensionNodeRpc.invoke') {
+        return 'ok'
+      }
+      return undefined
+    },
+  })
+
+  const rpc = await createNodeRpc({
+    id: 'codex-app-server',
+    legacyName: 'Codex App Server',
+    legacyPath: '/extensions/codex/node/dist/codexClient.js',
+  })
+
+  strictEqual(await rpc.invoke('Codex.listSessions'), 'ok')
+  await rpc.dispose()
+  deepStrictEqual(invocations, [
+    ['ExtensionNodeRpc.create', 'Codex App Server', '/extensions/codex/node/dist/codexClient.js'],
+    ['ExtensionNodeRpc.invoke', 7, 'Codex.listSessions'],
+    ['ExtensionNodeRpc.dispose', 7],
+  ])
+})
+
 test('createRpc transfers a port and worker options', async () => {
   const invocations: unknown[] = []
   mockRpc = ExtensionManagementWorker.registerMockRpc({


### PR DESCRIPTION
Allow isolated extensions to provide their own legacy Node RPC path when running against editor versions that predate capability-gated connections. Current editors continue to resolve and authorize RPC declarations by ID.