### PR TITLE
feature: add remote workspace extension interfaces

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -2,7 +2,7 @@ export { activate } from './parts/Activation/Activation.ts'
 export { getAccessToken, type GetAccessTokenOptions } from './parts/Authentication/Authentication.ts'
 export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
-export { showQuickPick } from './parts/QuickPick/QuickPick.ts'
+export { showQuickInput, showQuickPick } from './parts/QuickPick/QuickPick.ts'
 export { getPreference, setPreference } from './parts/Preferences/Preferences.ts'
 export { deleteSecret, getSecret, storeSecret } from './parts/SecretStorage/SecretStorage.ts'
 export { registerCommand } from './parts/CommandRegistry/CommandRegistry.ts'
@@ -41,8 +41,12 @@ export { registerFileChangeHandler, type FileChangeHandler, type FileChanges } f
 export {
   executeFileSystemProviderGetPathSeparator,
   executeFileSystemProviderIsReadonly,
+  executeFileSystemProviderMkdir,
   executeFileSystemProviderReadDirWithFileTypes,
   executeFileSystemProviderReadFile,
+  executeFileSystemProviderRemove,
+  executeFileSystemProviderRename,
+  executeFileSystemProviderWriteFile,
   getFileSystemProviderRegistrySnapshot,
   registerFileSystemProvider,
   resetFileSystemProviderRegistry,
@@ -53,6 +57,7 @@ export {
   getWorkspaceUri,
   handleWorkspaceRefresh,
   openUri,
+  setWorkspaceUri,
   showNotification,
   type NotificationType,
 } from './parts/Host/Host.ts'
@@ -168,6 +173,7 @@ export type { FileSystemDirent } from './parts/FileSystem/FileSystem.ts'
 export type { FileSystemProvider } from './parts/FileSystemProvider/FileSystemProvider.ts'
 export type { FileSystemProviderRegistrySnapshot } from './parts/FileSystemProviderRegistrySnapshot/FileSystemProviderRegistrySnapshot.ts'
 export type { RegisteredFileSystemProvider } from './parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts'
+export type { ShowQuickInputOptions } from './parts/ShowQuickInputOptions/ShowQuickInputOptions.ts'
 export type { HandleExtensionManagementMessagePortOptions } from './parts/HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 export type { HoverProvider, HoverProviderRegistrySnapshot, HoverResult, RegisteredHoverProvider } from './parts/Hover/Hover.ts'
 export type {

--- a/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
+++ b/packages/extension-api/src/parts/FileSystemProvider/FileSystemProvider.ts
@@ -3,7 +3,11 @@ import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
 export interface FileSystemProvider {
   readonly id: string
   readonly isReadonly?: () => boolean | Promise<boolean>
+  readonly mkdir?: (uri: string) => void | Promise<void>
   readonly pathSeparator?: string
   readonly readDirWithFileTypes?: (uri: string) => readonly FileSystemDirent[] | Promise<readonly FileSystemDirent[]>
   readonly readFile: (uri: string) => string | Promise<string>
+  readonly remove?: (uri: string) => void | Promise<void>
+  readonly rename?: (oldUri: string, newUri: string) => void | Promise<void>
+  readonly writeFile?: (uri: string, content: string) => void | Promise<void>
 }

--- a/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
@@ -24,6 +24,11 @@ const assertFileSystemProvider = (provider: FileSystemProvider): void => {
   if (provider.isReadonly !== undefined && typeof provider.isReadonly !== 'function') {
     throw new ExtensionApiError(`file system provider ${provider.id} has invalid isReadonly function`)
   }
+  for (const method of ['mkdir', 'remove', 'rename', 'writeFile'] as const) {
+    if (provider[method] !== undefined && typeof provider[method] !== 'function') {
+      throw new ExtensionApiError(`file system provider ${provider.id} has invalid ${method} function`)
+    }
+  }
   if (provider.pathSeparator !== undefined && typeof provider.pathSeparator !== 'string') {
     throw new ExtensionApiError(`file system provider ${provider.id} has invalid pathSeparator`)
   }
@@ -42,6 +47,38 @@ const getProvider = (id: string): RegisteredFileSystemProvider => {
 
 export const executeFileSystemProviderReadFile = async (id: string, uri: string): Promise<string> => {
   return getProvider(id).readFile(uri)
+}
+
+export const executeFileSystemProviderMkdir = async (id: string, uri: string): Promise<void> => {
+  const provider = getProvider(id)
+  if (!provider.mkdir) {
+    throw new ExtensionApiError(`file system provider ${id} is missing mkdir function`)
+  }
+  await provider.mkdir(uri)
+}
+
+export const executeFileSystemProviderRemove = async (id: string, uri: string): Promise<void> => {
+  const provider = getProvider(id)
+  if (!provider.remove) {
+    throw new ExtensionApiError(`file system provider ${id} is missing remove function`)
+  }
+  await provider.remove(uri)
+}
+
+export const executeFileSystemProviderRename = async (id: string, oldUri: string, newUri: string): Promise<void> => {
+  const provider = getProvider(id)
+  if (!provider.rename) {
+    throw new ExtensionApiError(`file system provider ${id} is missing rename function`)
+  }
+  await provider.rename(oldUri, newUri)
+}
+
+export const executeFileSystemProviderWriteFile = async (id: string, uri: string, content: string): Promise<void> => {
+  const provider = getProvider(id)
+  if (!provider.writeFile) {
+    throw new ExtensionApiError(`file system provider ${id} is missing writeFile function`)
+  }
+  await provider.writeFile(uri, content)
 }
 
 export const executeFileSystemProviderReadDirWithFileTypes = async (id: string, uri: string): Promise<readonly FileSystemDirent[]> => {
@@ -74,9 +111,13 @@ export const registerFileSystemProvider = (provider: FileSystemProvider): Dispos
   providers[provider.id] = {
     id: provider.id,
     isReadonly: provider.isReadonly,
+    mkdir: provider.mkdir,
     pathSeparator: provider.pathSeparator,
     readDirWithFileTypes: provider.readDirWithFileTypes,
     readFile: (uri) => provider.readFile(uri),
+    remove: provider.remove,
+    rename: provider.rename,
+    writeFile: provider.writeFile,
   }
   ExtensionApiCommandRegistry.registerCommandMap(commandMap)
   return {
@@ -89,8 +130,12 @@ export const registerFileSystemProvider = (provider: FileSystemProvider): Dispos
 const commandMap = {
   'ExtensionApi.executeFileSystemProviderGetPathSeparator': executeFileSystemProviderGetPathSeparator,
   'ExtensionApi.executeFileSystemProviderIsReadonly': executeFileSystemProviderIsReadonly,
+  'ExtensionApi.executeFileSystemProviderMkdir': executeFileSystemProviderMkdir,
   'ExtensionApi.executeFileSystemProviderReadDirWithFileTypes': executeFileSystemProviderReadDirWithFileTypes,
   'ExtensionApi.executeFileSystemProviderReadFile': executeFileSystemProviderReadFile,
+  'ExtensionApi.executeFileSystemProviderRemove': executeFileSystemProviderRemove,
+  'ExtensionApi.executeFileSystemProviderRename': executeFileSystemProviderRename,
+  'ExtensionApi.executeFileSystemProviderWriteFile': executeFileSystemProviderWriteFile,
   'ExtensionApi.getFileSystemProviderRegistrySnapshot': getFileSystemProviderRegistrySnapshot,
 }
 

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -25,3 +25,7 @@ export const openUri = async (uri: string): Promise<void> => {
 export const showNotification = async (type: NotificationType, message: string): Promise<void> => {
   await executeCommand('Notification.create', type, message)
 }
+
+export const setWorkspaceUri = async (uri: string): Promise<void> => {
+  await executeCommand('Workspace.setUri', uri)
+}

--- a/packages/extension-api/src/parts/QuickPick/QuickPick.ts
+++ b/packages/extension-api/src/parts/QuickPick/QuickPick.ts
@@ -1,5 +1,10 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import type { ShowQuickInputOptions } from '../ShowQuickInputOptions/ShowQuickInputOptions.ts'
 import type { ShowQuickPickOptions } from '../ShowQuickPickOptions/ShowQuickPickOptions.ts'
+
+export const showQuickInput = async (options: ShowQuickInputOptions = {}): Promise<string | undefined> => {
+  return ExtensionManagementWorker.invoke('ExtensionHostQuickPick.showQuickInput', options) as Promise<string | undefined>
+}
 
 export const showQuickPick = async (options: ShowQuickPickOptions): Promise<unknown> => {
   return ExtensionManagementWorker.invoke('ExtensionHostQuickPick.showQuickPick', options)

--- a/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
+++ b/packages/extension-api/src/parts/RegisteredFileSystemProvider/RegisteredFileSystemProvider.ts
@@ -3,7 +3,11 @@ import type { FileSystemDirent } from '../FileSystemDirent/FileSystemDirent.ts'
 export interface RegisteredFileSystemProvider {
   readonly id: string
   readonly isReadonly?: () => boolean | Promise<boolean>
+  readonly mkdir?: (uri: string) => void | Promise<void>
   readonly pathSeparator?: string
   readonly readDirWithFileTypes?: (uri: string) => readonly FileSystemDirent[] | Promise<readonly FileSystemDirent[]>
   readonly readFile: (uri: string) => string | Promise<string>
+  readonly remove?: (uri: string) => void | Promise<void>
+  readonly rename?: (oldUri: string, newUri: string) => void | Promise<void>
+  readonly writeFile?: (uri: string, content: string) => void | Promise<void>
 }

--- a/packages/extension-api/src/parts/ShowQuickInputOptions/ShowQuickInputOptions.ts
+++ b/packages/extension-api/src/parts/ShowQuickInputOptions/ShowQuickInputOptions.ts
@@ -1,0 +1,4 @@
+export interface ShowQuickInputOptions {
+  readonly placeholder?: string
+  readonly value?: string
+}

--- a/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
@@ -3,8 +3,12 @@ import { afterEach, test } from 'node:test'
 import {
   executeFileSystemProviderGetPathSeparator,
   executeFileSystemProviderIsReadonly,
+  executeFileSystemProviderMkdir,
   executeFileSystemProviderReadDirWithFileTypes,
   executeFileSystemProviderReadFile,
+  executeFileSystemProviderRemove,
+  executeFileSystemProviderRename,
+  executeFileSystemProviderWriteFile,
   getFileSystemProviderRegistrySnapshot,
   registerFileSystemProvider,
   resetFileSystemProviderRegistry,
@@ -15,17 +19,30 @@ afterEach(() => {
 })
 
 test('registerFileSystemProvider registers and executes provider operations', async () => {
+  const invocations: unknown[][] = []
   const disposable = registerFileSystemProvider({
     id: 'git-file-before',
     isReadonly() {
       return true
     },
     pathSeparator: '/',
+    mkdir(uri) {
+      invocations.push(['mkdir', uri])
+    },
     readDirWithFileTypes(uri) {
       return [{ name: uri, type: 1 }]
     },
     readFile(uri) {
       return `before:${uri}`
+    },
+    remove(uri) {
+      invocations.push(['remove', uri])
+    },
+    rename(oldUri, newUri) {
+      invocations.push(['rename', oldUri, newUri])
+    },
+    writeFile(uri, content) {
+      invocations.push(['writeFile', uri, content])
     },
   })
 
@@ -38,6 +55,16 @@ test('registerFileSystemProvider registers and executes provider operations', as
   ])
   strictEqual(executeFileSystemProviderGetPathSeparator('git-file-before'), '/')
   strictEqual(await executeFileSystemProviderIsReadonly('git-file-before'), true)
+  await executeFileSystemProviderMkdir('git-file-before', 'file:///workspace/folder')
+  await executeFileSystemProviderWriteFile('git-file-before', 'file:///workspace/file.txt', 'updated')
+  await executeFileSystemProviderRename('git-file-before', 'file:///workspace/file.txt', 'file:///workspace/renamed.txt')
+  await executeFileSystemProviderRemove('git-file-before', 'file:///workspace/renamed.txt')
+  deepStrictEqual(invocations, [
+    ['mkdir', 'file:///workspace/folder'],
+    ['writeFile', 'file:///workspace/file.txt', 'updated'],
+    ['rename', 'file:///workspace/file.txt', 'file:///workspace/renamed.txt'],
+    ['remove', 'file:///workspace/renamed.txt'],
+  ])
 
   disposable.dispose()
   deepStrictEqual(getFileSystemProviderRegistrySnapshot(), { providers: [] })
@@ -81,4 +108,32 @@ test('registerFileSystemProvider rejects invalid optional operations', () => {
       },
     })
   }, /file system provider invalid has invalid isReadonly function/)
+
+  throws(() => {
+    registerFileSystemProvider({
+      id: 'invalid-write',
+      readFile() {
+        return ''
+      },
+      // @ts-expect-error testing invalid provider shape
+      writeFile: true,
+    })
+  }, /file system provider invalid-write has invalid writeFile function/)
+})
+
+test('missing writable operations reject clearly', async () => {
+  registerFileSystemProvider({
+    id: 'read-only',
+    readFile() {
+      return ''
+    },
+  })
+
+  await rejects(executeFileSystemProviderMkdir('read-only', 'file:///workspace/folder'), /missing mkdir function/)
+  await rejects(executeFileSystemProviderRemove('read-only', 'file:///workspace/file.txt'), /missing remove function/)
+  await rejects(
+    executeFileSystemProviderRename('read-only', 'file:///workspace/file.txt', 'file:///workspace/renamed.txt'),
+    /missing rename function/,
+  )
+  await rejects(executeFileSystemProviderWriteFile('read-only', 'file:///workspace/file.txt', 'updated'), /missing writeFile function/)
 })

--- a/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
+++ b/packages/extension-api/test/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.test.ts
@@ -25,10 +25,10 @@ test('registerFileSystemProvider registers and executes provider operations', as
     isReadonly() {
       return true
     },
-    pathSeparator: '/',
     mkdir(uri) {
       invocations.push(['mkdir', uri])
     },
+    pathSeparator: '/',
     readDirWithFileTypes(uri) {
       return [{ name: uri, type: 1 }]
     },

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -1,7 +1,15 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { confirm, getWorkspaceFolder, getWorkspaceUri, handleWorkspaceRefresh, openUri, showNotification } from '../../../src/parts/Host/Host.ts'
+import {
+  confirm,
+  getWorkspaceFolder,
+  getWorkspaceUri,
+  handleWorkspaceRefresh,
+  openUri,
+  setWorkspaceUri,
+  showNotification,
+} from '../../../src/parts/Host/Host.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -37,6 +45,7 @@ test('host helpers execute renderer commands through extension management', asyn
   strictEqual(await confirm('Discard changes?'), true)
   await handleWorkspaceRefresh()
   await openUri('/workspace/file.txt')
+  await setWorkspaceUri('remote-ssh:///test-folder')
   await showNotification('info', 'File created successfully')
 
   deepStrictEqual(invocations, [
@@ -45,6 +54,7 @@ test('host helpers execute renderer commands through extension management', asyn
     ['ConfirmPrompt.prompt', 'Discard changes?'],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', '/workspace/file.txt'],
+    ['Workspace.setUri', 'remote-ssh:///test-folder'],
     ['Notification.create', 'info', 'File created successfully'],
   ])
 })

--- a/packages/extension-api/test/parts/QuickPick/QuickPick.test.ts
+++ b/packages/extension-api/test/parts/QuickPick/QuickPick.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { showQuickPick } from '../../../src/parts/QuickPick/QuickPick.ts'
+import { showQuickInput, showQuickPick } from '../../../src/parts/QuickPick/QuickPick.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -38,4 +38,31 @@ test('showQuickPick invokes extension host quick pick command', async () => {
 
   strictEqual(result, 'option-1')
   deepStrictEqual(invokedOptions, options)
+})
+
+test('showQuickInput invokes extension host quick input command', async () => {
+  let invokedOptions: unknown
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'ExtensionHostQuickPick.showQuickInput'(options: unknown): Promise<unknown> {
+      invokedOptions = options
+      return 'user@example.com'
+    },
+  })
+  const options = {
+    placeholder: 'Enter SSH host',
+    value: 'user@',
+  }
+
+  strictEqual(await showQuickInput(options), 'user@example.com')
+  deepStrictEqual(invokedOptions, options)
+})
+
+test('showQuickInput preserves cancellation', async () => {
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'ExtensionHostQuickPick.showQuickInput'(): Promise<unknown> {
+      return undefined
+    },
+  })
+
+  strictEqual(await showQuickInput(), undefined)
 })


### PR DESCRIPTION
Add free-form quick input, custom workspace URI switching, and writable isolated file-system provider operations for remote workspace extensions.