### PR TITLE
fix: forward workspace provider path separator

### DIFF
--- a/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
+++ b/packages/extension-api/src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts
@@ -93,6 +93,14 @@ export const executeFileSystemProviderGetPathSeparator = (id: string): string =>
   return getProvider(id).pathSeparator || '/'
 }
 
+export const getFileSystemProviderPathSeparator = (id: string): string | undefined => {
+  const provider = providers[id]
+  if (!provider) {
+    return undefined
+  }
+  return provider.pathSeparator || '/'
+}
+
 export const executeFileSystemProviderIsReadonly = async (id: string): Promise<boolean> => {
   const provider = getProvider(id)
   return provider.isReadonly ? provider.isReadonly() : false

--- a/packages/extension-api/src/parts/Host/Host.ts
+++ b/packages/extension-api/src/parts/Host/Host.ts
@@ -1,4 +1,5 @@
 import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+import { getFileSystemProviderPathSeparator } from '../FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
 
 export type NotificationType = 'error' | 'info' | 'warning'
 
@@ -27,5 +28,12 @@ export const showNotification = async (type: NotificationType, message: string):
 }
 
 export const setWorkspaceUri = async (uri: string): Promise<void> => {
-  await executeCommand('Workspace.setUri', uri)
+  const protocolEnd = uri.indexOf(':')
+  const protocol = protocolEnd === -1 ? '' : uri.slice(0, protocolEnd)
+  const pathSeparator = getFileSystemProviderPathSeparator(protocol)
+  if (pathSeparator === undefined) {
+    await executeCommand('Workspace.setUri', uri)
+    return
+  }
+  await executeCommand('Workspace.setUri', uri, pathSeparator)
 }

--- a/packages/extension-api/test/parts/Host/Host.test.ts
+++ b/packages/extension-api/test/parts/Host/Host.test.ts
@@ -2,6 +2,10 @@ import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import {
+  registerFileSystemProvider,
+  resetFileSystemProviderRegistry,
+} from '../../../src/parts/FileSystemProviderRegistry/FileSystemProviderRegistry.ts'
+import {
   confirm,
   getWorkspaceFolder,
   getWorkspaceUri,
@@ -20,6 +24,26 @@ let mockRpc: MockRpcDisposable | undefined
 afterEach(() => {
   mockRpc?.[Symbol.dispose]()
   mockRpc = undefined
+  resetFileSystemProviderRegistry()
+})
+
+test('setWorkspaceUri forwards a registered provider path separator', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+  registerFileSystemProvider({
+    id: 'remote-ssh',
+    pathSeparator: '/',
+    readFile: async () => '',
+  })
+
+  await setWorkspaceUri('remote-ssh:///test-folder')
+
+  deepStrictEqual(invocations, [['Workspace.setUri', 'remote-ssh:///test-folder', '/']])
 })
 
 test('host helpers execute renderer commands through extension management', async () => {


### PR DESCRIPTION
## Summary

- resolve a registered file-system provider path separator inside the isolated extension worker
- forward that separator with Workspace.setUri
- retain the existing fallback for URIs without a locally registered provider

This avoids a re-entrant provider RPC when an isolated file-system extension switches the workspace to its own scheme.

## Validation

- 210 extension API tests pass
- 5 tree-shaking tests pass
- type-check passes
- lint and formatting pass