### PR TITLE
feature: store extension output in indexeddb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6318,6 +6318,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10594,7 +10604,8 @@
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
       },
       "devDependencies": {
-        "@types/node": "^25.9.1"
+        "@types/node": "^25.9.1",
+        "fake-indexeddb": "^6.2.5"
       }
     },
     "packages/extension-api/node_modules/@lvce-editor/virtual-dom-worker": {

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -38,6 +38,7 @@
     "type-check": "tsc"
   },
   "devDependencies": {
-    "@types/node": "^25.9.1"
+    "@types/node": "^25.9.1",
+    "fake-indexeddb": "^6.2.5"
   }
 }

--- a/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
+++ b/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
@@ -3,9 +3,10 @@ import type { OutputChannelRegistrySnapshot } from '../OutputChannelRegistrySnap
 import type { RegisteredOutputChannel } from '../RegisteredOutputChannel/RegisteredOutputChannel.ts'
 import * as ExtensionApiCommandRegistry from '../ExtensionApiCommandRegistry/ExtensionApiCommandRegistry.ts'
 import { ExtensionApiError } from '../ExtensionApiError/ExtensionApiError.ts'
+import * as OutputChannelStorage from '../OutputChannelStorage/OutputChannelStorage.ts'
 
 const outputChannels: Record<string, RegisteredOutputChannel> = Object.create(null)
-const outputChannelLogs: Record<string, string> = Object.create(null)
+const outputChannelHandles: Record<string, ExtensionOutputChannel> = Object.create(null)
 let isActivated = false
 const RE_DASH_CASE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
 
@@ -26,34 +27,42 @@ const assertCanWrite = (id: string): void => {
 
 class ExtensionOutputChannel implements OutputChannel {
   readonly #id: string
+  #pendingWrite: Promise<void>
 
-  constructor(id: string) {
+  constructor(id: string, pendingWrite: Promise<void>) {
     this.#id = id
+    this.#pendingWrite = pendingWrite
+  }
+
+  #queueWrite(write: () => Promise<void>): Promise<void> {
+    this.#pendingWrite = this.#pendingWrite.then(write)
+    return this.#pendingWrite
   }
 
   async append(text: string): Promise<void> {
     assertCanWrite(this.#id)
-    outputChannelLogs[this.#id] += text
+    await this.#queueWrite(() => OutputChannelStorage.append(this.#id, text))
   }
 
   async appendLine(text: string): Promise<void> {
     assertCanWrite(this.#id)
-    outputChannelLogs[this.#id] += `${text}\n`
+    await this.#queueWrite(() => OutputChannelStorage.append(this.#id, `${text}\n`))
   }
 
   async clear(): Promise<void> {
     assertCanWrite(this.#id)
-    outputChannelLogs[this.#id] = ''
+    await this.#queueWrite(() => OutputChannelStorage.clear(this.#id))
   }
 
   async getLogs(): Promise<string> {
     assertCanWrite(this.#id)
-    return outputChannelLogs[this.#id]
+    await this.#pendingWrite
+    return OutputChannelStorage.getLogs(this.#id)
   }
 
   async replace(text: string): Promise<void> {
     assertCanWrite(this.#id)
-    outputChannelLogs[this.#id] = text
+    await this.#queueWrite(() => OutputChannelStorage.replace(this.#id, text))
   }
 }
 
@@ -69,9 +78,10 @@ export const createOutputChannel = (id: string): OutputChannel => {
   outputChannels[id] = {
     id,
   }
-  outputChannelLogs[id] = ''
   ExtensionApiCommandRegistry.registerCommandMap(commandMap)
-  return new ExtensionOutputChannel(id)
+  const handle = new ExtensionOutputChannel(id, OutputChannelStorage.clear(id))
+  outputChannelHandles[id] = handle
+  return handle
 }
 
 export const getOutputChannelRegistrySnapshot = (): OutputChannelRegistrySnapshot => {
@@ -80,15 +90,16 @@ export const getOutputChannelRegistrySnapshot = (): OutputChannelRegistrySnapsho
   }
 }
 
-export const getOutputChannelLogs = (id: string): string | undefined => {
-  return outputChannelLogs[id]
+export const getOutputChannelLogs = async (id: string): Promise<string | undefined> => {
+  return outputChannelHandles[id]?.getLogs()
 }
 
-export const clearOutputChannel = (id: string): boolean => {
-  if (!(id in outputChannelLogs)) {
+export const clearOutputChannel = async (id: string): Promise<boolean> => {
+  const handle = outputChannelHandles[id]
+  if (!handle) {
     return false
   }
-  outputChannelLogs[id] = ''
+  await handle.clear()
   return true
 }
 
@@ -102,8 +113,8 @@ export const resetOutputChannelRegistry = (): void => {
   for (const id of Object.keys(outputChannels)) {
     delete outputChannels[id]
   }
-  for (const id of Object.keys(outputChannelLogs)) {
-    delete outputChannelLogs[id]
+  for (const id of Object.keys(outputChannelHandles)) {
+    delete outputChannelHandles[id]
   }
   isActivated = false
 }

--- a/packages/extension-api/src/parts/OutputChannelStorage/OutputChannelStorage.ts
+++ b/packages/extension-api/src/parts/OutputChannelStorage/OutputChannelStorage.ts
@@ -1,0 +1,94 @@
+const databasePrefix = 'lvce-editor-extension-output'
+const databaseVersion = 1
+const objectStoreName = 'chunks'
+const channelIdIndexName = 'channelId'
+
+interface OutputChunk {
+  readonly channelId: string
+  readonly text: string
+}
+
+let databasePromise: Promise<IDBDatabase> | undefined
+
+const getDatabaseName = (): string => {
+  const extensionPath = typeof location === 'undefined' ? 'test' : location.pathname
+  return `${databasePrefix}:${extensionPath}`
+}
+
+const openDatabase = (): Promise<IDBDatabase> => {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(getDatabaseName(), databaseVersion)
+    request.onerror = () => reject(request.error)
+    request.onupgradeneeded = () => {
+      const database = request.result
+      const objectStore = database.createObjectStore(objectStoreName, {
+        autoIncrement: true,
+      })
+      objectStore.createIndex(channelIdIndexName, 'channelId')
+    }
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+const getDatabase = (): Promise<IDBDatabase> => {
+  databasePromise ||= openDatabase()
+  return databasePromise
+}
+
+const waitForTransaction = (transaction: IDBTransaction): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    transaction.onabort = () => reject(transaction.error)
+    transaction.onerror = () => reject(transaction.error)
+    transaction.oncomplete = () => resolve()
+  })
+}
+
+const deleteChannelChunks = (objectStore: IDBObjectStore, channelId: string, onComplete: () => void = () => {}): void => {
+  const index = objectStore.index(channelIdIndexName)
+  const request = index.openKeyCursor(IDBKeyRange.only(channelId))
+  request.onsuccess = () => {
+    const cursor = request.result
+    if (!cursor) {
+      onComplete()
+      return
+    }
+    objectStore.delete(cursor.primaryKey)
+    cursor.continue()
+  }
+}
+
+export const append = async (channelId: string, text: string): Promise<void> => {
+  const database = await getDatabase()
+  const transaction = database.transaction(objectStoreName, 'readwrite')
+  transaction.objectStore(objectStoreName).add({ channelId, text } satisfies OutputChunk)
+  await waitForTransaction(transaction)
+}
+
+export const clear = async (channelId: string): Promise<void> => {
+  const database = await getDatabase()
+  const transaction = database.transaction(objectStoreName, 'readwrite')
+  deleteChannelChunks(transaction.objectStore(objectStoreName), channelId)
+  await waitForTransaction(transaction)
+}
+
+export const getLogs = async (channelId: string): Promise<string> => {
+  const database = await getDatabase()
+  const transaction = database.transaction(objectStoreName, 'readonly')
+  const request = transaction.objectStore(objectStoreName).index(channelIdIndexName).getAll(IDBKeyRange.only(channelId))
+  const chunks = await new Promise<readonly OutputChunk[]>((resolve, reject) => {
+    request.onerror = () => reject(request.error)
+    request.onsuccess = () => resolve(request.result)
+  })
+  await waitForTransaction(transaction)
+  return chunks.map((chunk) => chunk.text).join('')
+}
+
+export const replace = async (channelId: string, text: string): Promise<void> => {
+  const database = await getDatabase()
+  const transaction = database.transaction(objectStoreName, 'readwrite')
+  const objectStore = transaction.objectStore(objectStoreName)
+  deleteChannelChunks(objectStore, channelId, () => {
+    objectStore.add({ channelId, text } satisfies OutputChunk)
+  })
+  await waitForTransaction(transaction)
+}

--- a/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
+++ b/packages/extension-api/test/parts/OutputChannel/OutputChannel.test.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
+import 'fake-indexeddb/auto'
 import {
   activateOutputChannels,
   clearOutputChannel,
@@ -170,11 +171,11 @@ test('getOutputChannelLogs returns output channel logs by id', async () => {
   await output.appendLine('sample')
   await output.append('logs')
 
-  strictEqual(getOutputChannelLogs('sample-output'), 'sample\nlogs')
+  strictEqual(await getOutputChannelLogs('sample-output'), 'sample\nlogs')
 })
 
-test('getOutputChannelLogs returns undefined for an unknown id', () => {
-  strictEqual(getOutputChannelLogs('unknown-output'), undefined)
+test('getOutputChannelLogs returns undefined for an unknown id', async () => {
+  strictEqual(await getOutputChannelLogs('unknown-output'), undefined)
 })
 
 test('clearOutputChannel clears output channel logs by id', async () => {
@@ -182,12 +183,25 @@ test('clearOutputChannel clears output channel logs by id', async () => {
   activateOutputChannels()
   await output.append('sample logs')
 
-  strictEqual(clearOutputChannel('sample-output'), true)
-  strictEqual(getOutputChannelLogs('sample-output'), '')
+  strictEqual(await clearOutputChannel('sample-output'), true)
+  strictEqual(await getOutputChannelLogs('sample-output'), '')
 })
 
-test('clearOutputChannel returns false for an unknown id', () => {
-  strictEqual(clearOutputChannel('unknown-output'), false)
+test('clearOutputChannel returns false for an unknown id', async () => {
+  strictEqual(await clearOutputChannel('unknown-output'), false)
+})
+
+test('preserves the order of many small output chunks', async () => {
+  const output = createOutputChannel('sample-output')
+  activateOutputChannels()
+  const writes: Promise<void>[] = []
+
+  for (let i = 0; i < 100; i++) {
+    writes.push(output.append(`${i},`))
+  }
+  await Promise.all(writes)
+
+  strictEqual(await output.getLogs(), `${Array.from({ length: 100 }, (_, index) => index).join(',')},`)
 })
 
 test('multiple channels invoke with their own ids', async () => {


### PR DESCRIPTION
Store isolated-extension output as ordered IndexedDB chunks while preserving the existing output-channel API, clear, replace, and read behavior.