### PR TITLE
fix: initialize output storage lazily

### DIFF
--- a/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
+++ b/packages/extension-api/src/parts/OutputChannel/OutputChannel.ts
@@ -27,15 +27,19 @@ const assertCanWrite = (id: string): void => {
 
 class ExtensionOutputChannel implements OutputChannel {
   readonly #id: string
-  #pendingWrite: Promise<void>
+  #pendingWrite: Promise<void> | undefined
 
-  constructor(id: string, pendingWrite: Promise<void>) {
+  constructor(id: string) {
     this.#id = id
-    this.#pendingWrite = pendingWrite
+  }
+
+  #initialize(): Promise<void> {
+    this.#pendingWrite ||= OutputChannelStorage.clear(this.#id)
+    return this.#pendingWrite
   }
 
   #queueWrite(write: () => Promise<void>): Promise<void> {
-    this.#pendingWrite = this.#pendingWrite.then(write)
+    this.#pendingWrite = this.#initialize().then(write)
     return this.#pendingWrite
   }
 
@@ -56,7 +60,7 @@ class ExtensionOutputChannel implements OutputChannel {
 
   async getLogs(): Promise<string> {
     assertCanWrite(this.#id)
-    await this.#pendingWrite
+    await this.#initialize()
     return OutputChannelStorage.getLogs(this.#id)
   }
 
@@ -79,7 +83,7 @@ export const createOutputChannel = (id: string): OutputChannel => {
     id,
   }
   ExtensionApiCommandRegistry.registerCommandMap(commandMap)
-  const handle = new ExtensionOutputChannel(id, OutputChannelStorage.clear(id))
+  const handle = new ExtensionOutputChannel(id)
   outputChannelHandles[id] = handle
   return handle
 }

--- a/packages/extension-api/test/parts/OutputChannel/OutputChannelWithoutIndexedDb.test.ts
+++ b/packages/extension-api/test/parts/OutputChannel/OutputChannelWithoutIndexedDb.test.ts
@@ -1,0 +1,24 @@
+import { doesNotThrow } from 'node:assert/strict'
+import { test } from 'node:test'
+import { createOutputChannel, resetOutputChannelRegistry } from '../../../src/parts/OutputChannel/OutputChannel.ts'
+
+test('createOutputChannel does not access IndexedDB before activation', () => {
+  const indexedDbDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'indexedDB')
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    get() {
+      throw new Error('IndexedDB accessed')
+    },
+  })
+
+  try {
+    doesNotThrow(() => createOutputChannel('sample-output'))
+  } finally {
+    resetOutputChannelRegistry()
+    if (indexedDbDescriptor) {
+      Object.defineProperty(globalThis, 'indexedDB', indexedDbDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'indexedDB')
+    }
+  }
+})


### PR DESCRIPTION
Initialize IndexedDB output storage on the first activated read or write so creating a channel remains safe in non-browser test environments.