### PR TITLE
feature: expose file content hashes

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -28,6 +28,7 @@ export {
 } from './parts/Formatting/Formatting.ts'
 export {
   exists,
+  getFileHash,
   mkdir,
   readAsObjectUrl,
   readDirWithFileTypes,

--- a/packages/extension-api/src/parts/FileSystem/FileSystem.ts
+++ b/packages/extension-api/src/parts/FileSystem/FileSystem.ts
@@ -48,6 +48,10 @@ export const readDirWithFileTypes = async (uri: string): Promise<readonly FileSy
   return FileSystemWorker.readDirWithFileTypes(uri)
 }
 
+export const getFileHash = async (uri: string): Promise<string> => {
+  return FileSystemWorker.invoke('FileSystem.getFileHash', uri)
+}
+
 export const readFile = async (uri: string): Promise<string> => {
   if (isMemory(uri)) {
     return ExtensionManagementWorker.invoke('ExtensionApi.readFile', uri)

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -1,7 +1,17 @@
 import { ExtensionManagementWorker, FileSystemWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { exists, mkdir, readAsObjectUrl, readDirWithFileTypes, readFile, remove, stat, writeFile } from '../../../src/parts/FileSystem/FileSystem.ts'
+import {
+  exists,
+  getFileHash,
+  mkdir,
+  readAsObjectUrl,
+  readDirWithFileTypes,
+  readFile,
+  remove,
+  stat,
+  writeFile,
+} from '../../../src/parts/FileSystem/FileSystem.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -29,6 +39,21 @@ test('readFile reads through the file system worker', async () => {
   const result = await readFile('/tmp/sample.txt')
 
   strictEqual(result, 'sample content')
+  strictEqual(invokedUri, '/tmp/sample.txt')
+})
+
+test('getFileHash reads the content hash through the file system worker', async () => {
+  let invokedUri = ''
+  mockRpc = FileSystemWorker.registerMockRpc({
+    async 'FileSystem.getFileHash'(uri: string): Promise<string> {
+      invokedUri = uri
+      return 'sample-hash'
+    },
+  })
+
+  const result = await getFileHash('/tmp/sample.txt')
+
+  strictEqual(result, 'sample-hash')
   strictEqual(invokedUri, '/tmp/sample.txt')
 })
 


### PR DESCRIPTION
Expose the existing filesystem content-hash command through the public extension API so extensions can build exact content-addressed caches.