### PR TITLE
fix: expose debug status commands

### DIFF
--- a/packages/extension-api/src/parts/Debug/Debug.ts
+++ b/packages/extension-api/src/parts/Debug/Debug.ts
@@ -12,7 +12,11 @@ export interface DebugEmitter {
 
 export interface DebugProvider {
   readonly evaluate: (expression: string, callFrameId: string) => unknown
+  readonly getCallStack: () => unknown
   readonly getProperties: (objectId: string) => unknown
+  readonly getScripts: () => unknown
+  readonly getScriptSource: (scriptId: string) => unknown
+  readonly getStatus: () => unknown
   readonly id: string
   readonly listProcesses: (path?: string) => unknown
   readonly pause: () => unknown
@@ -29,7 +33,11 @@ const providers: Record<string, DebugProvider> = Object.create(null)
 
 const requiredMethods = [
   'evaluate',
+  'getCallStack',
   'getProperties',
+  'getScripts',
+  'getScriptSource',
+  'getStatus',
   'listProcesses',
   'pause',
   'resume',
@@ -130,13 +138,33 @@ export const executeDebugGetProperties = async (id: string, objectId: string): P
   return getProvider(id).getProperties(objectId)
 }
 
+export const executeDebugGetCallStack = async (id: string): Promise<unknown> => {
+  return getProvider(id).getCallStack()
+}
+
+export const executeDebugGetPausedStatus = async (id: string): Promise<unknown> => {
+  return getProvider(id).getStatus()
+}
+
+export const executeDebugGetScripts = async (id: string): Promise<unknown> => {
+  return getProvider(id).getScripts()
+}
+
+export const executeDebugGetScriptSource = async (id: string, scriptId: string): Promise<unknown> => {
+  return getProvider(id).getScriptSource(scriptId)
+}
+
 export const executeDebugEvaluate = async (id: string, expression: string, callFrameId: string): Promise<unknown> => {
   return getProvider(id).evaluate(expression, callFrameId)
 }
 
 const commandMap = {
   'ExtensionHostDebug.evaluate': executeDebugEvaluate,
+  'ExtensionHostDebug.getCallStack': executeDebugGetCallStack,
+  'ExtensionHostDebug.getPausedStatus': executeDebugGetPausedStatus,
   'ExtensionHostDebug.getProperties': executeDebugGetProperties,
+  'ExtensionHostDebug.getScripts': executeDebugGetScripts,
+  'ExtensionHostDebug.getScriptSource': executeDebugGetScriptSource,
   'ExtensionHostDebug.listProcesses': executeDebugListProcesses,
   'ExtensionHostDebug.pause': executeDebugPause,
   'ExtensionHostDebug.resume': executeDebugResume,

--- a/packages/extension-api/test/parts/Debug/Debug.test.ts
+++ b/packages/extension-api/test/parts/Debug/Debug.test.ts
@@ -3,7 +3,11 @@ import { deepStrictEqual, rejects, strictEqual, throws } from 'node:assert/stric
 import { afterEach, test } from 'node:test'
 import {
   executeDebugEvaluate,
+  executeDebugGetCallStack,
+  executeDebugGetPausedStatus,
   executeDebugGetProperties,
+  executeDebugGetScripts,
+  executeDebugGetScriptSource,
   executeDebugListProcesses,
   executeDebugPause,
   executeDebugResume,
@@ -28,7 +32,11 @@ let mockRpc: MockRpcDisposable | undefined
 const createProvider = (overrides: Partial<DebugProvider> = {}): DebugProvider => {
   return {
     evaluate: () => 'evaluate',
+    getCallStack: () => ['frame-1'],
     getProperties: () => 'properties',
+    getScripts: () => ['script-1'],
+    getScriptSource: (scriptId) => `source:${scriptId}`,
+    getStatus: () => ({ status: 'unavailable' }),
     id: 'node-debug',
     listProcesses: () => [],
     pause: () => 'pause',
@@ -62,6 +70,10 @@ test('registerDebugProvider exposes provider methods', async () => {
   strictEqual(await executeDebugSetPauseOnExceptions('node-debug', 2), 'set-pause')
   strictEqual(await executeDebugGetProperties('node-debug', 'object-1'), 'properties')
   strictEqual(await executeDebugEvaluate('node-debug', '1 + 1', 'frame-1'), 'evaluate')
+  deepStrictEqual(await executeDebugGetCallStack('node-debug'), ['frame-1'])
+  deepStrictEqual(await executeDebugGetPausedStatus('node-debug'), { status: 'unavailable' })
+  deepStrictEqual(await executeDebugGetScripts('node-debug'), ['script-1'])
+  strictEqual(await executeDebugGetScriptSource('node-debug', 'script-1'), 'source:script-1')
 })
 
 test('executeDebugStart supplies a host event emitter', async () => {

--- a/packages/extension-api/test/parts/ExtensionApiCommandRegistry/ExtensionApiCommandRegistry.test.ts
+++ b/packages/extension-api/test/parts/ExtensionApiCommandRegistry/ExtensionApiCommandRegistry.test.ts
@@ -46,7 +46,11 @@ test('extension api commands are registered by capability', async () => {
 
   registerDebugProvider({
     evaluate() {},
+    getCallStack() {},
     getProperties() {},
+    getScripts() {},
+    getScriptSource() {},
+    getStatus() {},
     id: 'sample.debug',
     listProcesses() {},
     pause() {},
@@ -64,4 +68,8 @@ test('extension api commands are registered by capability', async () => {
   strictEqual(typeof debugCommandMap['ExtensionHostDebug.pause'], 'function')
   strictEqual(typeof debugCommandMap['ExtensionHostDebug.resume'], 'function')
   strictEqual(typeof debugCommandMap['ExtensionHostDebug.evaluate'], 'function')
+  strictEqual(typeof debugCommandMap['ExtensionHostDebug.getCallStack'], 'function')
+  strictEqual(typeof debugCommandMap['ExtensionHostDebug.getPausedStatus'], 'function')
+  strictEqual(typeof debugCommandMap['ExtensionHostDebug.getScripts'], 'function')
+  strictEqual(typeof debugCommandMap['ExtensionHostDebug.getScriptSource'], 'function')
 })


### PR DESCRIPTION
## Summary

- expose the debug status and inspection RPC commands used by the Run and Debug worker
- require registered debug providers to implement the corresponding methods
- cover direct provider dispatch and command registration

## Validation

- `npm test --workspace=@lvce-editor/api` (213 passed)
- `npm run type-check`
- `npm run lint`
- `npm run build`

This completes the activity-bar dogfood finding where opening Run and Debug left the renderer command queue awaiting `ExtensionHostDebug.getPausedStatus`, preventing later activity-bar switches.