### PR TITLE
feature: expose binary file reads to extensions

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -33,6 +33,7 @@ export {
   readAsObjectUrl,
   readDirWithFileTypes,
   readFile,
+  readFileAsBlob,
   remove,
   stat,
   writeFile,

--- a/packages/extension-api/src/parts/FileSystem/FileSystem.ts
+++ b/packages/extension-api/src/parts/FileSystem/FileSystem.ts
@@ -62,6 +62,10 @@ export const readFile = async (uri: string): Promise<string> => {
   return FileSystemWorker.readFile(uri)
 }
 
+export const readFileAsBlob = async (uri: string): Promise<Blob> => {
+  return FileSystemWorker.invoke('FileSystem.readFileAsBlob', uri)
+}
+
 export const readAsObjectUrl = async (uri: string): Promise<ReadAsObjectUrlResult> => {
   try {
     const objectUrl = await getObjectUrl(uri)

--- a/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
+++ b/packages/extension-api/test/parts/FileSystem/FileSystem.test.ts
@@ -8,6 +8,7 @@ import {
   readAsObjectUrl,
   readDirWithFileTypes,
   readFile,
+  readFileAsBlob,
   remove,
   stat,
   writeFile,
@@ -40,6 +41,22 @@ test('readFile reads through the file system worker', async () => {
 
   strictEqual(result, 'sample content')
   strictEqual(invokedUri, '/tmp/sample.txt')
+})
+
+test('readFileAsBlob reads binary content through the file system worker', async () => {
+  let invokedUri = ''
+  const blob = new Blob(['sample content'])
+  mockRpc = FileSystemWorker.registerMockRpc({
+    async 'FileSystem.readFileAsBlob'(uri: string): Promise<Blob> {
+      invokedUri = uri
+      return blob
+    },
+  })
+
+  const result = await readFileAsBlob('/tmp/sample.bin')
+
+  strictEqual(result, blob)
+  strictEqual(invokedUri, '/tmp/sample.bin')
 })
 
 test('getFileHash reads the content hash through the file system worker', async () => {


### PR DESCRIPTION
Expose the file-system worker's existing binary read command through the extension API. This lets isolated extensions decode binary formats without direct network access.