### PR TITLE
feature: expose panel view APIs

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -71,6 +71,14 @@ export {
   resetSignatureHelpProviderRegistry,
 } from './parts/SignatureHelp/SignatureHelp.ts'
 export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
+export {
+  openDebugConsole,
+  openOutputView,
+  openProblemsView,
+  type OpenDebugConsoleOptions,
+  type OpenOutputViewOptions,
+  type OpenProblemsViewOptions,
+} from './parts/Panel/Panel.ts'
 export { getLanguageServerRegistrySnapshot, registerLanguageServer, resetLanguageServerRegistry } from './parts/LanguageServer/LanguageServer.ts'
 export {
   registerBraceCompletionProvider,

--- a/packages/extension-api/src/parts/Panel/Panel.ts
+++ b/packages/extension-api/src/parts/Panel/Panel.ts
@@ -1,0 +1,25 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export interface OpenDebugConsoleOptions {
+  readonly input?: string
+}
+
+export interface OpenOutputViewOptions {
+  readonly channel?: string
+}
+
+export interface OpenProblemsViewOptions {
+  readonly filter?: string
+}
+
+export const openDebugConsole = async (options: OpenDebugConsoleOptions = {}): Promise<void> => {
+  await executeCommand('Layout.openDebugConsole', options.input)
+}
+
+export const openOutputView = async (options: OpenOutputViewOptions = {}): Promise<void> => {
+  await executeCommand('Layout.openOutput', options.channel)
+}
+
+export const openProblemsView = async (options: OpenProblemsViewOptions = {}): Promise<void> => {
+  await executeCommand('Layout.openProblems', options.filter)
+}

--- a/packages/extension-api/test/parts/Panel/Panel.test.ts
+++ b/packages/extension-api/test/parts/Panel/Panel.test.ts
@@ -1,0 +1,55 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { openDebugConsole, openOutputView, openProblemsView } from '../../../src/parts/Panel/Panel.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('opens panel views with options', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await openProblemsView({ filter: 'typescript' })
+  await openOutputView({ channel: 'Window' })
+  await openDebugConsole({ input: 'process.version' })
+
+  deepStrictEqual(invocations, [
+    ['Layout.openProblems', 'typescript'],
+    ['Layout.openOutput', 'Window'],
+    ['Layout.openDebugConsole', 'process.version'],
+  ])
+})
+
+test('opens panel views without replacing their current options', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await openProblemsView()
+  await openOutputView()
+  await openDebugConsole()
+
+  deepStrictEqual(invocations, [
+    ['Layout.openProblems', undefined],
+    ['Layout.openOutput', undefined],
+    ['Layout.openDebugConsole', undefined],
+  ])
+})


### PR DESCRIPTION
Exposes extension APIs for opening Problems, Output, and Debug Console with optional initial view values.