### PR TITLE
feature: expose active editor APIs

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -7,6 +7,7 @@ export { getPreference, setPreference } from './parts/Preferences/Preferences.ts
 export { deleteSecret, getSecret, storeSecret } from './parts/SecretStorage/SecretStorage.ts'
 export { registerCommand } from './parts/CommandRegistry/CommandRegistry.ts'
 export { registerDebugProvider, resetDebugProviderRegistry } from './parts/Debug/Debug.ts'
+export { formatDocument, getDiagnostics, showCompletions } from './parts/Editor/Editor.ts'
 export {
   executeCompletionProvider,
   executeResolveCompletionItemProvider,

--- a/packages/extension-api/src/parts/Editor/Editor.ts
+++ b/packages/extension-api/src/parts/Editor/Editor.ts
@@ -1,0 +1,14 @@
+import type { Diagnostic } from '../DiagnosticResult/DiagnosticResult.ts'
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export const formatDocument = async (): Promise<void> => {
+  await executeCommand('Editor.format')
+}
+
+export const getDiagnostics = async (): Promise<readonly Diagnostic[]> => {
+  return (await executeCommand('GetActiveEditor.getDiagnostics')) as readonly Diagnostic[]
+}
+
+export const showCompletions = async (): Promise<void> => {
+  await executeCommand('Editor.openCompletion')
+}

--- a/packages/extension-api/test/parts/Editor/Editor.test.ts
+++ b/packages/extension-api/test/parts/Editor/Editor.test.ts
@@ -1,0 +1,35 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { formatDocument, getDiagnostics, showCompletions } from '../../../src/parts/Editor/Editor.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('executes active editor commands', async () => {
+  const diagnostics = [{ columnIndex: 1, endColumnIndex: 2, endRowIndex: 0, message: 'Unexpected semicolon', rowIndex: 0, type: 'warning' }]
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      if (id === 'GetActiveEditor.getDiagnostics') {
+        return diagnostics
+      }
+      return undefined
+    },
+  })
+
+  await formatDocument()
+  deepStrictEqual(await getDiagnostics(), diagnostics)
+  await showCompletions()
+
+  deepStrictEqual(invocations, [['Editor.format'], ['GetActiveEditor.getDiagnostics'], ['Editor.openCompletion']])
+})


### PR DESCRIPTION
Expose isolated extension APIs for formatting the active document, reading its diagnostics, and showing completion suggestions.