### PR TITLE
feature: add process explorer extension API

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -72,6 +72,7 @@ export {
   resetSignatureHelpProviderRegistry,
 } from './parts/SignatureHelp/SignatureHelp.ts'
 export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
+export { openProcessExplorer } from './parts/ProcessExplorer/ProcessExplorer.ts'
 export {
   openDebugConsole,
   openOutputView,

--- a/packages/extension-api/src/parts/ProcessExplorer/ProcessExplorer.ts
+++ b/packages/extension-api/src/parts/ProcessExplorer/ProcessExplorer.ts
@@ -1,0 +1,5 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export const openProcessExplorer = async (): Promise<void> => {
+  await executeCommand('Developer.openProcessExplorer')
+}

--- a/packages/extension-api/test/parts/ProcessExplorer/ProcessExplorer.test.ts
+++ b/packages/extension-api/test/parts/ProcessExplorer/ProcessExplorer.test.ts
@@ -1,0 +1,29 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { openProcessExplorer } from '../../../src/parts/ProcessExplorer/ProcessExplorer.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('opens the process explorer', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await openProcessExplorer()
+
+  deepStrictEqual(invocations, [['Developer.openProcessExplorer']])
+})


### PR DESCRIPTION
Adds a public `openProcessExplorer` API that opens the editor process explorer through the existing renderer command.