### PR TITLE
feature: expose open settings api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -3,7 +3,7 @@ export { getAccessToken, type GetAccessTokenOptions } from './parts/Authenticati
 export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showFileQuickPick, showQuickInput, showQuickPick } from './parts/QuickPick/QuickPick.ts'
-export { getPreference, setPreference } from './parts/Preferences/Preferences.ts'
+export { getPreference, openSettings, setPreference } from './parts/Preferences/Preferences.ts'
 export { deleteSecret, getSecret, storeSecret } from './parts/SecretStorage/SecretStorage.ts'
 export { registerCommand } from './parts/CommandRegistry/CommandRegistry.ts'
 export { registerDebugProvider, resetDebugProviderRegistry } from './parts/Debug/Debug.ts'

--- a/packages/extension-api/src/parts/Preferences/Preferences.ts
+++ b/packages/extension-api/src/parts/Preferences/Preferences.ts
@@ -1,7 +1,12 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
 
 export const getPreference = async (key: string): Promise<unknown> => {
   return ExtensionManagementWorker.invoke('Extensions.getPreference', key)
+}
+
+export const openSettings = async (): Promise<void> => {
+  await executeCommand('Preferences.openSettingsUi')
 }
 
 export const setPreference = async (key: string, value: unknown): Promise<void> => {

--- a/packages/extension-api/test/parts/Preferences/Preferences.test.ts
+++ b/packages/extension-api/test/parts/Preferences/Preferences.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { getPreference, setPreference } from '../../../src/parts/Preferences/Preferences.ts'
+import { getPreference, openSettings, setPreference } from '../../../src/parts/Preferences/Preferences.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -27,6 +27,20 @@ test('getPreference invokes extension management worker', async () => {
 
   strictEqual(result, 16)
   strictEqual(invokedKey, 'editor.fontSize')
+})
+
+test('openSettings opens the settings UI', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await openSettings()
+
+  deepStrictEqual(invocations, [['Preferences.openSettingsUi']])
 })
 
 test('setPreference invokes extension management worker', async () => {


### PR DESCRIPTION
Adds an openSettings() extension API that opens the LVCE Editor settings UI.