### PR TITLE
fix: open process explorer through uri

### DIFF
--- a/packages/extension-api/src/parts/ProcessExplorer/ProcessExplorer.ts
+++ b/packages/extension-api/src/parts/ProcessExplorer/ProcessExplorer.ts
@@ -1,5 +1,5 @@
-import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+import { openUri } from '../Host/Host.ts'
 
 export const openProcessExplorer = async (): Promise<void> => {
-  await executeCommand('Developer.openProcessExplorer')
+  await openUri('process-explorer://')
 }

--- a/packages/extension-api/test/parts/ProcessExplorer/ProcessExplorer.test.ts
+++ b/packages/extension-api/test/parts/ProcessExplorer/ProcessExplorer.test.ts
@@ -25,5 +25,5 @@ test('opens the process explorer', async () => {
 
   await openProcessExplorer()
 
-  deepStrictEqual(invocations, [['Developer.openProcessExplorer']])
+  deepStrictEqual(invocations, [['Main.openUri', 'process-explorer://']])
 })


### PR DESCRIPTION
Routes `openProcessExplorer` through the existing safe URI-opening capability so isolated extensions can use it without access to privileged developer commands.