### PR TITLE
feature: expose settings search value api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -3,7 +3,7 @@ export { getAccessToken, type GetAccessTokenOptions } from './parts/Authenticati
 export { createElectronWebContentsView } from './parts/ElectronWebContentsView/ElectronWebContentsView.ts'
 export { executeCommand } from './parts/ExecuteCommand/ExecuteCommand.ts'
 export { showFileQuickPick, showQuickInput, showQuickPick } from './parts/QuickPick/QuickPick.ts'
-export { getPreference, openSettings, setPreference } from './parts/Preferences/Preferences.ts'
+export { getPreference, openSettings, setPreference, setSettingsSearchValue } from './parts/Preferences/Preferences.ts'
 export { deleteSecret, getSecret, storeSecret } from './parts/SecretStorage/SecretStorage.ts'
 export { registerCommand } from './parts/CommandRegistry/CommandRegistry.ts'
 export { registerDebugProvider, resetDebugProviderRegistry } from './parts/Debug/Debug.ts'

--- a/packages/extension-api/src/parts/Preferences/Preferences.ts
+++ b/packages/extension-api/src/parts/Preferences/Preferences.ts
@@ -9,6 +9,10 @@ export const openSettings = async (): Promise<void> => {
   await executeCommand('Preferences.openSettingsUi')
 }
 
+export const setSettingsSearchValue = async (value: string): Promise<void> => {
+  await executeCommand('Settings.handleInput', value)
+}
+
 export const setPreference = async (key: string, value: unknown): Promise<void> => {
   await ExtensionManagementWorker.invoke('Extensions.setPreference', key, value)
 }

--- a/packages/extension-api/test/parts/Preferences/Preferences.test.ts
+++ b/packages/extension-api/test/parts/Preferences/Preferences.test.ts
@@ -1,7 +1,7 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { deepStrictEqual, strictEqual } from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { getPreference, openSettings, setPreference } from '../../../src/parts/Preferences/Preferences.ts'
+import { getPreference, openSettings, setPreference, setSettingsSearchValue } from '../../../src/parts/Preferences/Preferences.ts'
 
 interface MockRpcDisposable {
   [Symbol.dispose](): void
@@ -41,6 +41,20 @@ test('openSettings opens the settings UI', async () => {
   await openSettings()
 
   deepStrictEqual(invocations, [['Preferences.openSettingsUi']])
+})
+
+test('setSettingsSearchValue updates the settings search input', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await setSettingsSearchValue('font size')
+
+  deepStrictEqual(invocations, [['Settings.handleInput', 'font size']])
 })
 
 test('setPreference invokes extension management worker', async () => {


### PR DESCRIPTION
Expose a typed extension API for setting the Settings editor search input value.