### PR TITLE
feature: expose editor tab focus api

### DIFF
--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -80,6 +80,7 @@ export {
   resetSignatureHelpProviderRegistry,
 } from './parts/SignatureHelp/SignatureHelp.ts'
 export { getPlatform, type Platform } from './parts/Platform/Platform.ts'
+export { focusNextTab, focusPreviousTab } from './parts/MainArea/MainArea.ts'
 export { openProcessExplorer } from './parts/ProcessExplorer/ProcessExplorer.ts'
 export {
   openDebugConsole,

--- a/packages/extension-api/src/parts/MainArea/MainArea.ts
+++ b/packages/extension-api/src/parts/MainArea/MainArea.ts
@@ -1,0 +1,9 @@
+import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
+
+export const focusNextTab = async (): Promise<void> => {
+  await executeCommand('Main.focusNextTab')
+}
+
+export const focusPreviousTab = async (): Promise<void> => {
+  await executeCommand('Main.focusPreviousTab')
+}

--- a/packages/extension-api/test/parts/MainArea/MainArea.test.ts
+++ b/packages/extension-api/test/parts/MainArea/MainArea.test.ts
@@ -1,0 +1,43 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { deepStrictEqual } from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { focusNextTab, focusPreviousTab } from '../../../src/parts/MainArea/MainArea.ts'
+
+interface MockRpcDisposable {
+  [Symbol.dispose](): void
+}
+
+let mockRpc: MockRpcDisposable | undefined
+
+afterEach(() => {
+  mockRpc?.[Symbol.dispose]()
+  mockRpc = undefined
+})
+
+test('focuses the next editor tab', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await focusNextTab()
+
+  deepStrictEqual(invocations, [['Main.focusNextTab']])
+})
+
+test('focuses the previous editor tab', async () => {
+  const invocations: unknown[][] = []
+  mockRpc = ExtensionManagementWorker.registerMockRpc({
+    async 'Extensions.executeCommand'(id: string, ...args: readonly unknown[]): Promise<unknown> {
+      invocations.push([id, ...args])
+      return undefined
+    },
+  })
+
+  await focusPreviousTab()
+
+  deepStrictEqual(invocations, [['Main.focusPreviousTab']])
+})


### PR DESCRIPTION
Adds first-class extension APIs for focusing the next or previous editor tab.