### PR TITLE
fix: render settings search api value

### DIFF
--- a/packages/extension-api/src/parts/Preferences/Preferences.ts
+++ b/packages/extension-api/src/parts/Preferences/Preferences.ts
@@ -1,6 +1,8 @@
 import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { executeCommand } from '../ExecuteCommand/ExecuteCommand.ts'
 
+const ScriptInputSource = 2
+
 export const getPreference = async (key: string): Promise<unknown> => {
   return ExtensionManagementWorker.invoke('Extensions.getPreference', key)
 }
@@ -10,7 +12,7 @@ export const openSettings = async (): Promise<void> => {
 }
 
 export const setSettingsSearchValue = async (value: string): Promise<void> => {
-  await executeCommand('Settings.handleInput', value)
+  await executeCommand('Settings.handleInput', value, ScriptInputSource)
 }
 
 export const setPreference = async (key: string, value: unknown): Promise<void> => {

--- a/packages/extension-api/test/parts/Preferences/Preferences.test.ts
+++ b/packages/extension-api/test/parts/Preferences/Preferences.test.ts
@@ -54,7 +54,7 @@ test('setSettingsSearchValue updates the settings search input', async () => {
 
   await setSettingsSearchValue('font size')
 
-  deepStrictEqual(invocations, [['Settings.handleInput', 'font size']])
+  deepStrictEqual(invocations, [['Settings.handleInput', 'font size', 2]])
 })
 
 test('setPreference invokes extension management worker', async () => {


### PR DESCRIPTION
Mark extension-driven Settings search updates as scripted input so the value is rendered into the search field.